### PR TITLE
Updates on MC normalization at nlo and further data-MC tuning

### DIFF
--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -206,51 +206,41 @@
             "msize": 0.7,
             "tag": "data"
          },
-        {
+       {
             "color": 15,
             "data": [
                 {
                     "br": [
-                        1.0
+                        0.5
                     ],
                     "dset": [
-                        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
 		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_ZZ2l2q_2016",
-                    "xsec": 3.22
+                    "dtag": "MC13TeV_ZZ_2016",
+                    "xsec": 16.523 
                 },
                 {
                     "br": [
-                        1.0
+                        0.5
                     ],
                     "dset": [
-                        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
 		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_ZZ2l2nu_2016",
-                    "xsec": 0.564
-                },
-		{
-		  "br": [
-		      1.0
-		   ],
-		   "dset": [
-		      "/ZZTo4L_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-		   ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_ZZTo4L_2016",
-		    "xsec": 1.256
-	       }
+                    "dtag": "MC13TeV_ZZ_ext1_2016",
+                    "xsec": 16.523
+                }
             ],
             "isdata": false,
             "keys": [
-                "haa_mcbased"
+                "haa_mcbased",
+		"haa_prod"
             ],
             "tag": "ZZ"
         },
         {
-            "color": 17,
+            "color": 16,
             "data": [
                 {
                     "br": [
@@ -284,34 +274,45 @@
 		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WWlnu2q_ext1_2016",
                     "xsec": 49.997
-                },
-		{
-		     "br": [
-                        1
-                    ],
-                    "dset": [
-                        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-                    ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_WZ3lnu_2016",
-                    "xsec": 4.42965
-                },
-                {
-                    "br": [
-                        1
-                    ],
-                    "dset": [
-                        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-                    ],
-                    "dtag": "MC13TeV_WZ2l2q_2016",
-                    "xsec": 5.595
                 }
             ],
             "isdata": false,
             "keys": [
                 "haa_mcbased"
             ],
-            "tag": "WV"
+            "tag": "WW"
+        },
+	{
+		"color": 17, 
+		 "data": [ 
+                     {
+		     "br": [
+                        0.25
+                    ],
+                    "dset": [
+		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WZ_2016",
+                    "xsec": 47.13 
+                    },
+                   {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZ_ext1_2016",
+                    "xsec": 47.13 
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased",
+		"haa_prod"
+            ],
+            "tag": "WZ"
         },
         {
             "color": 14,
@@ -428,66 +429,32 @@
 	    ],
             "isdata": false,
             "keys": [
-                "haa_mcbased",
-		"haa_test"
+                "haa_mcbased"
             ],
             "tag": "Single Top"
         },
-        {
+	{
             "color": 592,
-            "data": [
-                {
-                    "br": [
-                        0.2
-                    ],
-                    "dset": [
-         		"/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-                    ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_TTJets_DiLept_2016",
-                    "xsec": 87.31
-                },
-		{
-		    "br": [
-		        0.8
+	    "data": [
+	    {
+	       "br": [
+	          1.0
 		],
-		"dset": [
-		    "/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
-		],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_TTJets_DiLept_ext1_2016",
-		    "xsec": 87.31   
-		},
-		{
-		   "br": [
-		      0.25
-		    ],
-		    "dset": [
-			"/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-		    ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_TTJets_SingleLeptFromTbar_2016",
-		    "xsec": 182.17 
-		},
-		{
-		  "br": [
-		    0.75
-		    ],
-		    "dset": [
-			"/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
-		    ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_TTJets_SingleLeptFromTbar_ext1_2016",
-		    "xsec": 182.17
-		    }
-            ],
-            "isdata": false,
-            "keys": [
-                "haa_mcbased",
-		"haa_tt"
-            ],
-            "tag": "t#bar{t}+jets"
-        },
+		"dset": [ 
+		  "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+		  ],
+		  "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+		  "dtag": "MC13TeV_TTJets_2016",
+		  "xsec": 831.76
+	    }
+	    ],
+	     "isdata": false,
+	      "keys": [
+	         "haa_mcbased",
+		 "haa_test"
+		 ],
+	     "tag": "t#bar{t}+jets"
+	}, 
         {
             "color": 595,
             "data": [


### PR DESCRIPTION
- MC normalization has been fixed to take into account negative weight events with amcatNLO samples. Big improvement on data-MC agreement.
- Replaced ttjets single-lep and dilepton Madgraph samples with amcatnloFXFX TTJets inclusive. Also replaced ZZ and WZ samples with the inclusive ones.
- Added upper cut on MT at 250 GeV (to consider tighten it in the future).
- Switched to N-1 plots for jets, b-jets, SVs and ak8. Added 2D plots in b-tag vs ak8 multiplicity for optimization studies.