### PR TITLE
Adapt Amin's new miniAOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ```bash
 export SCRAM_ARCH=slc6_amd64_gcc530
-cmsrel CMSSW_8_0_26_patch1
-cd CMSSW_8_0_26_patch1/src
+cmsrel CMSSW_8_0_27
+cd CMSSW_8_0_27/src
 cmsenv
 git cms-init
 #Checkout Some Packages from Egamma ( https://twiki.cern.ch/twiki/bin/viewauth/CMS/EGMRegression#Consistent_EGMSmearer )

--- a/scripts/LaunchOnCondor.py
+++ b/scripts/LaunchOnCondor.py
@@ -246,7 +246,7 @@ def CreateCrabConfig(crabWorkDir, crabConfigPath, exePath, cfgPath):
     config_file.write('\n')
     config_file.write('config.Data.inputDataset = \''+Jobs_CRABDataset+'\'\n')
     config_file.write('config.Data.lumiMask = "'+Jobs_CRABlumiMask+'"\n')
-#    config_file.write('config.Data.inputDBS = "%s"\n' % Jobs_CRABInDBS)
+    config_file.write('config.Data.inputDBS = "%s"\n' % Jobs_CRABInDBS)
     config_file.write('config.Data.splitting = \''+Jobs_CRABsplitting+'\'\n')
     config_file.write('config.Data.unitsPerJob = %d\n' % Jobs_CRABUnitPerJob)
     config_file.write('config.Data.totalUnits = -1\n')
@@ -255,11 +255,15 @@ def CreateCrabConfig(crabWorkDir, crabConfigPath, exePath, cfgPath):
     if Jobs_CRABLFN == '':
         config_file.write('#config.Data.outLFNDirBase = \'/store/user/<username>/debug\'\n')
     else:
-        config_file.write('config.Data.outLFNDirBase = \'/store/user/'+commands.getstatusoutput("whoami")[1]+'/'+Jobs_CRABLFN+'\'\n')
-        print 'config.Data.outLFNDirBase = \'/store/user/'+commands.getstatusoutput("whoami")[1]+'/'+Jobs_CRABLFN+'\'\n'
+        if(commands.getstatusoutput("whoami")[1]=='hwei'):
+          config_file.write('config.Data.outLFNDirBase = \'/store/user/hua/'+Jobs_CRABLFN+'\'\n')
+          print 'config.Data.outLFNDirBase = \'/store/user/hua/'+Jobs_CRABLFN+'\'\n'
+        else:
+          config_file.write('config.Data.outLFNDirBase = \'/store/user/'+commands.getstatusoutput("whoami")[1]+'/'+Jobs_CRABLFN+'\'\n')
+          print 'config.Data.outLFNDirBase = \'/store/user/'+commands.getstatusoutput("whoami")[1]+'/'+Jobs_CRABLFN+'\'\n'
     config_file.write('\n')
     config_file.write('config.Site.storageSite = \''+Jobs_CRABStorageSite+'\'\n')
-    config_file.write('config.Site.whitelist = [\'T2_CH_CERN\',\'T2_US_UCSD\']')
+    config_file.write('config.Site.whitelist = [\'T2_CH_CERN\',\'T2_US_UCSD\',\'T3_US_FNALLPC\']')
     config_file.close()
 
 

--- a/scripts/runAnalysisOverSamples.py
+++ b/scripts/runAnalysisOverSamples.py
@@ -221,6 +221,7 @@ hostname = commands.getstatusoutput("hostname -f")[1]
 if(hostname.find("ucl.ac.be")!=-1):localTier = "T2_BE_UCL"
 if(hostname.find("iihe.ac.be")!=-1):localTier = "T2_BE_IIHE"
 if(hostname.find("cern.ch")!=-1)  :localTier = "T2_CH_CERN"
+if(hostname.find("fnal.gov")!=-1)  :localTier = "T3_US_FNALLPC"
 
 FarmDirectory                      = opt.outdir+"/FARM"
 PROXYDIR                           = FarmDirectory+"/inputs"
@@ -369,6 +370,8 @@ for procBlock in procList :
                           LaunchOnCondor.Jobs_CRABexe      = opt.theExecutable
                           if(commands.getstatusoutput("whoami")[1]=='georgia'):
                               LaunchOnCondor.Jobs_CRABStorageSite = 'T2_CH_CERN'
+                          elif(commands.getstatusoutput("whoami")[1]=='hwei'):
+                              LaunchOnCondor.Jobs_CRABStorageSite = 'T3_US_FNALLPC'
                           else: LaunchOnCondor.Jobs_CRABStorageSite = 'T2_US_UCSD'
                           if(isdata): 
                               LaunchOnCondor.Jobs_CRABsplitting = 'LumiBased'
@@ -377,7 +380,10 @@ for procBlock in procList :
                               LaunchOnCondor.Jobs_CRABsplitting = 'FileBased'
                               LaunchOnCondor.Jobs_CRABUnitPerJob = 5
                           LaunchOnCondor.Jobs_CRABname     = dtag + '_' + str(s)
-                          LaunchOnCondor.Jobs_CRABInDBS    = getByLabel(procData,'dbsURL','global')
+                          if( 'signal' in opt.onlykeyword):
+                            LaunchOnCondor.Jobs_CRABInDBS    = getByLabel(procData,'dbsURL','phys03')
+                          else:
+                            LaunchOnCondor.Jobs_CRABInDBS    = getByLabel(procData,'dbsURL','global')
 #                          if(split>0):
 #                              LaunchOnCondor.Jobs_CRABUnitPerJob = 100 / split 
 #                          else:

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -715,6 +715,93 @@
             "resonance": 50,
             "spimpose": true,
             "tag": "Wh (50)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Private_production_m12_Nov_13_MiniAOD-9fa49160dc28c3dbeac6b80d5ed131ae/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass12",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 594,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": true,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Private_production_m15_Nov_13_MiniAOD-9fa49160dc28c3dbeac6b80d5ed131ae/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass15",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 594,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": true,
+            "tag": "Wh (15)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Private_production_m30_Nov_13_MiniAOD-9fa49160dc28c3dbeac6b80d5ed131ae/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass30",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 594,
+            "lwidth": 3,
+            "lstyle": 5,
+            "resonance": 30,
+            "spimpose": true,
+            "tag": "Wh (30)"
         }
     ]
 }

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -1,16 +1,16 @@
 {
     "proc": [
-         {
+        {
             "color": 1,
-            "data": [		
-		{
+            "data": [
+                {
                     "br": [
                         1.0
                     ],
                     "dset": [
                         "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016B_ver2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -22,7 +22,7 @@
                     "dset": [
                         "/SingleElectron/Run2016C-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016C",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -34,7 +34,7 @@
                     "dset": [
                         "/SingleElectron/Run2016D-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016D",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -46,7 +46,7 @@
                     "dset": [
                         "/SingleElectron/Run2016E-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016E",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -58,7 +58,7 @@
                     "dset": [
                         "/SingleElectron/Run2016F-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016F",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -70,7 +70,7 @@
                     "dset": [
                         "/SingleElectron/Run2016G-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleElectron2016G",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -82,7 +82,7 @@
                     "dset": [
                         "/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_Prompt_v16",
+                    "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleElectron2016H_ver2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -94,19 +94,19 @@
                     "dset": [
                         "/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_Prompt_v16",
+                    "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleElectron2016H_ver3",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
-	 	{
+                {
                     "br": [
                         1.0
                     ],
                     "dset": [
                         "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016B_ver2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -118,7 +118,7 @@
                     "dset": [
                         "/SingleMuon/Run2016C-03Feb2017-v1/MINIAOD"
                     ],
-		     "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                     "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016C",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -130,7 +130,7 @@
                     "dset": [
                         "/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016D",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -142,7 +142,7 @@
                     "dset": [
                         "/SingleMuon/Run2016E-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016E",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -154,7 +154,7 @@
                     "dset": [
                         "/SingleMuon/Run2016F-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016F",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -166,7 +166,7 @@
                     "dset": [
                         "/SingleMuon/Run2016G-03Feb2017-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
                     "dtag": "Data13TeV_SingleMuon2016G",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -178,7 +178,7 @@
                     "dset": [
                         "/SingleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_Prompt_v16",
+                    "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleMuon2016H_ver2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -190,7 +190,7 @@
                     "dset": [
                         "/SingleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
                     ],
-		    "gtag": "80X_dataRun2_Prompt_v16",
+                    "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleMuon2016H_ver3",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
                     "xsec": 1.0
@@ -200,13 +200,13 @@
             "isdata": true,
             "keys": [
                 "haa_mcbased",
-		"haa_dataOnly"
+                "haa_dataOnly"
             ],
             "marker": 20,
             "msize": 0.7,
             "tag": "data"
-         },
-       {
+        },
+        {
             "color": 18,
             "data": [
                 {
@@ -214,9 +214,9 @@
                         0.5
                     ],
                     "dset": [
-		       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_ZZ_2016",
                     "xsec": 16.523 
                 },
@@ -225,9 +225,9 @@
                         0.5
                     ],
                     "dset": [
-		       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_ZZ_ext1_2016",
                     "xsec": 16.523
                 },
@@ -238,7 +238,7 @@
                     "dset": [
                         "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WW2l2nu_2016",
                     "xsec": 12.178
                 },
@@ -249,7 +249,7 @@
                     "dset": [
                         "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WWlnu2q_2016",
                     "xsec": 49.997
                 },
@@ -260,18 +260,18 @@
                     "dset": [
                         "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WWlnu2q_ext1_2016",
                     "xsec": 49.997
                 },
                 {
-		     "br": [
+                     "br": [
                         0.25
                     ],
                     "dset": [
-		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WZ_2016",
                     "xsec": 47.13 
                     },
@@ -280,7 +280,7 @@
                         0.75
                     ],
                     "dset": [
-		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
                     "dtag": "MC13TeV_WZ_ext1_2016",
                     "xsec": 47.13 
@@ -302,7 +302,7 @@
                     "dset": [
                         "/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_ZZZ_2016",
                     "xsec": 0.01398
                 },
@@ -313,7 +313,7 @@
                     "dset": [
                         "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WZZ_2016",
                     "xsec": 0.05565
                 },
@@ -324,21 +324,21 @@
                     "dset": [
                         "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WWZ_2016",
                     "xsec": 0.1651
                 },
-		{	
-		   "br": [
-		     1.0
-		   ],
-		   "dset": [
-		     "/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"  
-		   ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		   "dtag": "MC13TeV_WWW_4F_2016",
-		   "xsec": 0.2086
-		}     
+                {
+                   "br": [
+                     1.0
+                   ],
+                   "dset": [
+                     "/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"  
+                   ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                   "dtag": "MC13TeV_WWW_4F_2016",
+                   "xsec": 0.2086
+                }     
             ],
             "isdata": false,
             "keys": [
@@ -346,30 +346,30 @@
             ],
             "tag": "ZVV"
         },
-	{
-            "color": 831,	
+        {
+            "color": 831,
             "data": [
-		{
+                {
                     "br": [
                         1.0
                     ],
                     "dset": [
                         "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_SingleT_s_2016",
                     "xsec": 3.362
                 },
-		{
-		   "br": [                                                                                                                                         
+                {
+                   "br": [                                                                                                                                         
                         1.0  
                     ], 
-		    "dset": [ 
-		    	"/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
-		    ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_SingleT_at_2016",
-		    "xsec": 136.02 
+                    "dset": [ 
+                        "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_at_2016",
+                    "xsec": 136.02 
                 },
                 {
                     "br": [
@@ -378,7 +378,7 @@
                     "dset": [
                         "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_SingleT_t_2016",
                     "xsec": 80.95
                 },
@@ -389,7 +389,7 @@
                     "dset": [
                         "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_SingleT_atW_2016",
                     "xsec": 35.6
                 },
@@ -400,39 +400,39 @@
                     "dset": [
                         "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_SingleT_tW_2016",
                     "xsec": 35.6
                 }
-	    ],
+            ],
             "isdata": false,
             "keys": [
                 "haa_mcbased"
             ],
             "tag": "Single Top"
         },
-	{
+        {
             "color": 408,
-	    "data": [
-	    {
-	       "br": [
-	          1.0
-		],
-		"dset": [ 
-		  "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
-		  ],
-		  "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		  "dtag": "MC13TeV_TTJets_2016",
-		  "xsec": 831.76
-	    }
-	    ],
-	     "isdata": false,
-	      "keys": [
-	         "haa_mcbased",
-		 "haa_test"
-		 ],
-	     "tag": "t#bar{t}+jets"
-	}, 
+            "data": [
+                {
+                    "br": [
+                        1.0
+                     ],
+                    "dset": [ 
+                        "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_2016",
+                    "xsec": 831.76
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                 "haa_mcbased",
+                 "haa_test"
+            ],
+            "tag": "t#bar{t}+jets"
+        }, 
         {
             "color": 424,
             "data": [
@@ -443,7 +443,7 @@
                     "dset": [
                         "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TTGJets_2016",
                     "xsec": 3.697
                 },
@@ -454,7 +454,7 @@
                     "dset": [
                         "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TGJets_2016",
                     "xsec": 2.967
                 },
@@ -465,18 +465,18 @@
                     "dset": [
                         "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TGJets_ext1_2016",
                     "xsec": 2.967
                 },
-		{
+                {
                     "br": [
                         1
                     ],
                     "dset": [
                         "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TTWJetslnu_2016",
                     "xsec": 0.2043
                 },
@@ -487,7 +487,7 @@
                     "dset": [
                         "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TTZJets2l2nu_2016",
                     "xsec": 0.2529
                 }
@@ -506,30 +506,30 @@
                         1.0
                     ],
                     "dset": [
-		        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
-             	{
-	       	"br": [ 1.0 ],
-		"dset": [
-		   "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
-		],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag":  "MC13TeV_DYJetsToLL_50toInf_2016",
-		    "xsec": 5765.4 
-		}
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "xsec": 5765.4 
+                }
             ],
             "isdata": false,
             "keys": [
                 "haa_mcbased",
-		"haa_ztoll"
+                "haa_ztoll"
             ],
             "tag": "Z#rightarrow ll"
         },
-	{
+        {
             "color": 622,
             "data": [
                 {
@@ -539,18 +539,18 @@
                     "dset": [
                         "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_WJets_2016",
                     "xsec": 61526.7
                 }
-	    ],
+            ],
             "isdata": false,
             "keys": [
                 "haa_mcbased"
             ],
             "tag": "W#rightarrow l#nu"
         },
-	{
+        {
             "color": 634,
             "data": [
                 {
@@ -560,7 +560,7 @@
                     "dset": [
                         "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt20To30_EMEnr_2016",
                     "xsec": 557600000
                 },
@@ -571,7 +571,7 @@
                     "dset": [
                         "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt30To50_EMEnr_2016",
                     "xsec": 136000000
                 },
@@ -582,7 +582,7 @@
                     "dset": [
                         "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt30To50_EMEnr_ext1_2016",
                     "xsec": 136000000
                 },
@@ -593,7 +593,7 @@
                     "dset": [
                         "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt50To80_EMEnr_2016",
                     "xsec": 19800000
                 },
@@ -604,7 +604,7 @@
                     "dset": [
                         "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2016",
                     "xsec": 2800000
                 },
@@ -615,7 +615,7 @@
                     "dset": [
                         "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2016",
                     "xsec": 477000
                 },
@@ -626,7 +626,7 @@
                     "dset": [
                         "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2016",
                     "xsec": 114000
                 },
@@ -637,7 +637,7 @@
                     "dset": [
                         "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2016",
                     "xsec": 9000
                 },
@@ -648,7 +648,7 @@
                     "dset": [
                         "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_QCD_Pt20ToInf_MuEnr_2016",
                     "xsec": 720648000
                 }
@@ -658,7 +658,7 @@
                 "haa_mcbased"
             ],
             "tag": "QCD"
-          },
+        },
         {
             "data": [
                 {
@@ -668,7 +668,7 @@
                     "dset": [
                         "/MinBias/sghiasis-crab_Wh_m20_MiniAOD-28028af67189b3de7224b79195bd0e1d/USER"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_Wh_amass20",
                     "xsec": 1.37
                 }
@@ -687,7 +687,7 @@
             "spimpose": true,
             "tag": "Wh (20)"
         },
-	{
+        {
             "data": [
                 {
                     "br": [
@@ -696,7 +696,7 @@
                     "dset": [
                         "/MinBias/sghiasis-crab_Wh_m50_MiniAOD-28028af67189b3de7224b79195bd0e1d/USER"
                     ],
-		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_Wh_amass50",
                     "xsec": 1.37
                 }
@@ -711,7 +711,7 @@
             ],
             "lcolor": 594,
             "lwidth": 3,
-	    "lstyle": 2,
+            "lstyle": 2,
             "resonance": 50,
             "spimpose": true,
             "tag": "Wh (50)"

--- a/test/haa4b/submit.sh
+++ b/test/haa4b/submit.sh
@@ -36,7 +36,8 @@ if [[ $# -ge 4 ]]; then echo "Additional arguments will be considered: "$argumen
 
 #SUFFIX=_2017_09_18
 #SUFFIX=_2017_09_20 #Data
-SUFFIX=_2017_09_21 #BG MC
+#SUFFIX=_2017_09_21 #BG MC
+SUFFIX=_2017_11_14 #SG MC
 
 #SUFFIX=$(date +"_%Y_%m_%d") 
 MAINDIR=$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b
@@ -94,8 +95,9 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
        echo "JOB SUBMISSION for Ntuplization using full CMSSW fwk"
        echo "Input: " $JSON
        echo "Output: " $RESULTSDIR
-       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_dataOnly -s crab
-#       runAnalysisOverSamples.py -e runNtuplizer -j $JSON -o $RESULTSDIR  -c $MAINDIR/../runNtuplizer_cfg.py.templ -p "@data_pileup=datapileup_latest @verbose=False" -s $queue --report True --key haa_test $arguments
+       #runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_dataOnly -s crab
+			 runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab -t MC13TeV_Wh_amass50
+       #runAnalysisOverSamples.py -e runNtuplizer -j $JSON -o $RESULTSDIR  -c $MAINDIR/../runNtuplizer_cfg.py.templ -p "@data_pileup=datapileup_latest @verbose=False" -s $queue --report True --key haa_test $arguments
    fi    
 
    if [[ $step == 1.1 ]]; then  #submit jobs for h->aa->XXYY analysis

--- a/test/haa4b/submit.sh
+++ b/test/haa4b/submit.sh
@@ -96,7 +96,7 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
        echo "Input: " $JSON
        echo "Output: " $RESULTSDIR
        #runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_dataOnly -s crab
-       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab -t MC13TeV_Wh_amass50
+       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab #-t MC13TeV_Wh_amass50
        #runAnalysisOverSamples.py -e runNtuplizer -j $JSON -o $RESULTSDIR  -c $MAINDIR/../runNtuplizer_cfg.py.templ -p "@data_pileup=datapileup_latest @verbose=False" -s $queue --report True --key haa_test $arguments
    fi    
 

--- a/test/haa4b/submit.sh
+++ b/test/haa4b/submit.sh
@@ -96,7 +96,7 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
        echo "Input: " $JSON
        echo "Output: " $RESULTSDIR
        #runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_dataOnly -s crab
-			 runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab -t MC13TeV_Wh_amass50
+       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab -t MC13TeV_Wh_amass50
        #runAnalysisOverSamples.py -e runNtuplizer -j $JSON -o $RESULTSDIR  -c $MAINDIR/../runNtuplizer_cfg.py.templ -p "@data_pileup=datapileup_latest @verbose=False" -s $queue --report True --key haa_test $arguments
    fi    
 


### PR DESCRIPTION
Changes:
1. CMSSW_8_0_26_patch1 to CMSSW_8_0_27. Confirmed with Amin, 8026 not working with deep csv
2. use opt.onlykeyword to set "config.Data.inputDBS" for signal (global for default, phys03 for signal MC)
3. Add T3 FNAL, deal with the user name difference on the fnal/lxplus for hua (hwei vs hua). PS: I just have eos storage in fnal t3, cern box stroage seems not working with crab
4. Format tuning and new samples added in samples2016.json (A mass, 12, 15, 30)

Test with ./submit 1.0, success. This is backward compatible (I test with previous miniAOD, without deep csv, also works)