### PR TITLE
More MC for MVA train

### DIFF
--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -502,25 +502,33 @@
             "color": 624,
             "data": [
                 {
-                    "br": [
-                        1.0
-                    ],
+                    "br": [ 1.0 ],
                     "dset": [
-                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
                 {
-                    "br": [ 1.0 ],
+                    "br": [ 0.337 ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
                     "xsec": 5765.4 
+                },
+                {
+                    "br": [ 0.663 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 5765.4
                 }
+
             ],
             "isdata": false,
             "keys": [

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -419,10 +419,76 @@
                         1.0
                      ],
                     "dset": [ 
-                        "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+                        "/TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                      ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_TTJets_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.0423793
+                     ],
+                    "dset": [ 
+                        "/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_slt_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.177275
+                     ],
+                    "dset": [
+                        "/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_slt_ext1_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.0435732
+                     ],
+                    "dset": [ 
+                        "/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_slat_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.176081
+                     ],
+                    "dset": [ 
+                        "/TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_slat_ext1_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.0212484
+                     ],
+                    "dset": [ 
+                        "/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_dl_2016",
+                    "xsec": 831.76
+                },
+                {
+                    "br": [
+                        0.0848972
+                     ],
+                    "dset": [
+                        "/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_dl_ext1_2016",
                     "xsec": 831.76
                 }
             ],

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -502,27 +502,27 @@
             "color": 624,
             "data": [
                 {
-                    "br": [ 1.0 ],
+                    "br": [ 0.434 ],
                     "dset": [
-                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
                     "xsec": 18610
                 },
                 {
-                    "br": [ 0.337 ],
+                    "br": [ 0.566 ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+                        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
-                    "xsec": 5765.4 
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_ext1_2016",
+                    "xsec": 18610
                 },
                 {
-                    "br": [ 0.663 ],
+                    "br": [ 1.0 ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",

--- a/test/haa4b/submit.sh
+++ b/test/haa4b/submit.sh
@@ -39,7 +39,7 @@ if [[ $# -ge 4 ]]; then echo "Additional arguments will be considered: "$argumen
 #SUFFIX=_2017_09_21 #BG MC
 #SUFFIX=_2017_11_15 #SG MC, but deepcsv in 8027
 #SUFFIX=_2017_12_11 #New SG MC from Amin, deepcsv rework, functional in 8026_patch1
-SUFFIX=_2017_12_12 #LO WJets test
+SUFFIX=_2017_12_12 #LO Samples test
 
 #SUFFIX=$(date +"_%Y_%m_%d") 
 MAINDIR=$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b
@@ -99,7 +99,7 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
        echo "Output: " $RESULTSDIR
        #runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_dataOnly -s crab
        #runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_signal -s crab #-t MC13TeV_Wh_amass50
-       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_mcbased -s crab -t MC13TeV_WJets_ext2_2016
+       runAnalysisOverSamples.py -j $JSON -o $RESULTSDIR  -c $MAINDIR/../fullAnalysis_cfg.py.templ -l results$SUFFIX -p "@verbose=False" --key haa_mcbased -s crab -t MC13TeV_DYJetsToLL_10to50_2016
        #runAnalysisOverSamples.py -e runNtuplizer -j $JSON -o $RESULTSDIR  -c $MAINDIR/../runNtuplizer_cfg.py.templ -p "@data_pileup=datapileup_latest @verbose=False" -s $queue --report True --key haa_test $arguments
    fi    
 


### PR DESCRIPTION
TTJets:
Drop NLO sample.

Add:
Dataset: /TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
Creation time: 2016-12-10 04:21:46, Dataset size: 529.5GB, Number of blocks: 12, Number of events: 11957043, Number of files: 167, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM
Creation time: 2016-12-08 20:15:10, Dataset size: 2.2TB, Number of blocks: 40, Number of events: 50016934, Number of files: 629, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
Creation time: 2017-01-07 07:17:20, Dataset size: 529.6GB, Number of blocks: 26, Number of events: 11944041, Number of files: 196, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM
Creation time: 2016-12-08 20:17:56, Dataset size: 2.1TB, Number of blocks: 25, Number of events: 48266353, Number of files: 559, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
Creation time: 2016-11-29 11:49:49, Dataset size: 262.0GB, Number of blocks: 9, Number of events: 6094476, Number of files: 83, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM
Creation time: 2016-12-09 15:24:40, Dataset size: 1.0TB, Number of blocks: 32, Number of events: 24350202, Number of files: 342, Physics group: NoGroup, Status: VALID, Type: mc

Dataset: /TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
Creation time: 2017-01-30 02:05:16, Dataset size: 448.1GB, Number of blocks: 61, Number of events: 10139950, Number of files: 197, Physics group: NoGroup, Status: VALID, Type: mc

DY:
Add extension for M10to50
Dataset: /DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM
Creation time: 2017-01-05 03:29:37, Dataset size: 960.7GB, Number of blocks: 79, Number of events: 40381391, Number of files: 467, Physics group: NoGroup, Status: VALID, Type: mc

Branching ratio normalized with factors (eg single lepton br or di lepton br), and number of events.
Code:

#include <iostream>
int main( int argc, char *argv[] )
{
  float slbr = 0.43930872, dlbr = 0.10614564;
  float Nslt = 11957043, Nslt_ext = 50016934, Nslat = 11944041, Nslat_ext = 48266353;
  float Ndl = 6094476, Ndl_ext = 24350202;

  std::cout << "Single Lepton, from Top: " << 0.5 * slbr * Nslt / ( Nslt + Nslt_ext ) << ", ext1: " << 0.5 * slbr * Nslt_ext / ( Nslt + Nslt_ext ) << std::endl;
  std::cout << "Single Lepton, from anti-Top: " << 0.5 * slbr * Nslat / ( Nslat + Nslat_ext ) << ", ext1: "<< 0.5 * slbr * Nslat_ext / ( Nslat + Nslat_ext ) << std::endl;
  std::cout << "Double Lepton: " << dlbr * Ndl / ( Ndl + Ndl_ext ) << ", ext1: " << dlbr * Ndl_ext / ( Ndl + Ndl_ext ) << std::endl;
  return 0;
}
