### PR TITLE
Switched to LO madgraph DYJets_50toInf samples

### DIFF
--- a/interface/statWgt.h
+++ b/interface/statWgt.h
@@ -35,7 +35,12 @@ const std::map<std::string, int> mStat =
     //DY
     { "MC13TeV_DYJetsToLL_10to50_2016", 51433009 }, //12.9777*0.434 },
     { "MC13TeV_DYJetsToLL_10to50_ext1_2016", 51433009 }, // 12.9777*0.566 },
-    { "MC13TeV_DYJetsToLL_50toInf_2016", 81781064 }, //2.52854 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext1_2016", 232851034 }, //81781064 }, //2.52854 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext2_2016", 232851034 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext3_2016", 232851034 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext4_2016", 232851034 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext5_2016", 232851034 },
+    { "MC13TeV_DYJetsToLL_50toInf_ext6_2016", 232851034 },
     //TG, TTG, TTW, TTZ
     { "MC13TeV_TGJets_2016", 368562 }, //0.288736*0.25 },
     { "MC13TeV_TGJets_ext1_2016", 368562 }, //0.288736*0.75 },

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -207,7 +207,7 @@
             "tag": "data"
         },
         {
-            "color": 592,
+            "color": 590,
             "data": [
                 {
                     "br": [
@@ -575,15 +575,59 @@
                     "xsec": 18610
                 },
                 {
-                    "br": [ 1.0 ],
+                    "br": [ 0.2 ],
                     "dset": [
-                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+		       "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_DYJetsToLL_50toInf_2016",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+                    "xsec": 5765.4
+                },
+		{
+                    "br": [ 0.4 ],
+                    "dset": [
+			"/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 5765.4
+                },
+		{
+                    "br": [ 0.26 ],
+                    "dset": [
+			"/DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext3_2016",
+                    "xsec": 5765.4
+                },
+		{
+                    "br": [ 0.08 ],
+                    "dset": [
+			"/DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext4_2016",
+                    "xsec": 5765.4
+                },
+		{
+                    "br": [ 0.04 ],
+                    "dset": [
+			"/DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext5_2016",
+                    "xsec": 5765.4
+                },
+		{
+                    "br": [ 0.02 ],
+                    "dset": [
+			"/DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext6_2016",
                     "xsec": 5765.4
                 }
-
             ],
             "isdata": false,
             "keys": [
@@ -625,7 +669,7 @@
             "tag": "W#rightarrow l#nu"
         },
         {
-            "color": 390,
+            "color": 634,
             "data": [
                 {
                     "br": [
@@ -755,8 +799,8 @@
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
-            "lwidth": 2,
+            "lcolor": 1,
+            "lwidth": 3,
             "resonance": 20,
             "spimpose": true,
             "tag": "Wh (20)"
@@ -777,17 +821,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 2,
             "resonance": 50,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (50)"
         },
         {
@@ -806,17 +850,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 3,
             "resonance": 12,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (12)"
         },
         {
@@ -835,17 +879,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 4,
             "resonance": 15,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (15)"
         },
         {   
@@ -864,17 +908,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 5, 
             "resonance": 25,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (25)"
         },
         {
@@ -893,17 +937,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 6,
             "resonance": 30,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (30)"
         },
         {   
@@ -922,17 +966,17 @@
             ],
             "fill": 0,
             "isdata": false,
-            "isinvisible": false,
+            "isinvisible": true,
             "issignal": true,
             "keys": [
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3, 
             "lstyle": 7, 
             "resonance": 40,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (40)"
         },
         {
@@ -957,7 +1001,7 @@
                 "haa_signal",
                 "haa_mcbased"
             ],
-            "lcolor": 634,
+            "lcolor": 1,
             "lwidth": 3,
             "lstyle": 8,
             "resonance": 60,


### PR DESCRIPTION
The Ntuples are ready at the usual place: /eos/cms/store/user/georgia/results_2017_09_21/