### PR TITLE
Residual updates for 2nd round of ntuplization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,32 @@
 
 ```bash
 export SCRAM_ARCH=slc6_amd64_gcc530
+#or:
+setenv SCRAM_ARCH slc6_amd64_gcc530
 cmsrel CMSSW_8_0_26_patch1
 cd CMSSW_8_0_26_patch1/src
 cmsenv
-git cms-init
-#Only if you need DeepCSV
-git cms-merge-topic -u mverzett:DeepFlavour-from-CMSSW_8_0_21
-mkdir $CMSSW_BASE/src/RecoBTag/DeepFlavour/data/
-cd $CMSSW_BASE/src/RecoBTag/DeepFlavour/data/ 
-wget http://home.fnal.gov/~verzetti//DeepFlavour/training/DeepFlavourNoSL.json 
-cd $CMSSW_BASE/src/
-scram b -j 8
  
-#Checkout Some Packages from Egamma ( https://twiki.cern.ch/twiki/bin/viewauth/CMS/EGMRegression#Consistent_EGMSmearer )
+#Checkout Some Packages from Egamma 
+# ( https://twiki.cern.ch/twiki/bin/viewauth/CMS/EGMRegression#Consistent_EGMSmearer )
+git cms-init 
 git cms-merge-topic cms-egamma:EGM_gain_v1
 cd $CMSSW_BASE/src/EgammaAnalysis/ElectronTools/data
 git clone -b Moriond17_gainSwitch_unc https://github.com/ECALELFS/ScalesSmearings.git
 cd $CMSSW_BASE/src
 scram b -j 8
 
+#Adding DeepCSV (optional)   
+git cms-merge-topic -u mverzett:DeepFlavour-from-CMSSW_8_0_21 
+mkdir $CMSSW_BASE/src/RecoBTag/DeepFlavour/data/
+cd $CMSSW_BASE/src/RecoBTag/DeepFlavour/data/  
+wget http://home.fnal.gov/~verzetti//DeepFlavour/training/DeepFlavourNoSL.json
+cd $CMSSW_BASE/src/ 
+scram b -j 8
+
 # Check out packages for Hbb tagging (https://twiki.cern.ch/twiki/bin/viewauth/CMS/Hbbtagging#8_0_X)
 setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
-or
+#or
 export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 git remote add btv-cmssw https://github.com/cms-btv-pog/cmssw.git
@@ -31,7 +35,7 @@ git fetch --tags btv-cmssw
 git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
 scram b -j 8
 
-git clone -b svFit_2015Apr03 https://github.com/veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
+#git clone -b svFit_2015Apr03 https://github.com/veelken/SVfit_standalone.git TauAnalysis/SVfitStandalone
 
 git clone https://github.com/bsmAnalysis/BSMHiggs_fwk.git UserCode/bsmhiggs_fwk
 cd $CMSSW_BASE/src/UserCode/bsmhiggs_fwk

--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -783,7 +783,7 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
        ev.mn=0;
        //       for (std::vector<pat::Muon >::const_iterator mu = muons.begin(); mu!=muons.end(); mu++) 
        for(pat::Muon &mu : muons) {
-	 if(mu.pt() < 3) continue;
+	 if(mu.pt() < 5.) continue;
 	 ev.mn_px[ev.mn] = mu.px();
 	 ev.mn_py[ev.mn] = mu.py();
 	 ev.mn_pz[ev.mn] = mu.pz();
@@ -855,7 +855,7 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
        for (pat::Electron &el : electrons) {
        //       for( View<pat::ElectronCollection>::const_iterator el = electrons.begin(); el != electrons.end(); el++ ) 
 	 float pt_ = el.pt();
-	 if (pt_ < 5) continue;
+	 if (pt_ < 10.) continue;
 
 	 // Kinematics
 	 ev.en_px[ev.en] = el.px();

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -368,7 +368,7 @@
                         "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_SingleT_at_2016",
+                    "dtag": "MC13TeV_SingleT_t_2016",
                     "xsec": 136.02 
                 },
                 {
@@ -379,7 +379,7 @@
                         "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
                     ],
                     "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "dtag": "MC13TeV_SingleT_at_2016",
                     "xsec": 80.95
                 },
                 {
@@ -892,8 +892,8 @@
             ],
             "tag": "QCD"
         },
-{
-            "color": 634,
+        {
+            "color": 390,
             "data": [
                 {
                     "br": [


### PR DESCRIPTION
- Updated README for clean instructions and Combine tool in 80x
- Increased pt threshold in electron/muon collections [e: 5->10, mu: 3->5]
- Fixed reversed labels for two single top samples in json
- separate color index for QCD BCtoE in samples json