### PR TITLE
Add temporary json to use

### DIFF
--- a/test/haa4b/samples2016.json.tmp
+++ b/test/haa4b/samples2016.json.tmp
@@ -1,0 +1,935 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleElectron2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleElectron2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                     "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleMuon2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleMuon2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+                "haa_mcbased",
+                "haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 590,
+            "data": [
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZ_2016",
+                    "xsec": 16.523 
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZ_ext1_2016",
+                    "xsec": 16.523
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WW2l2nu_2016",
+                    "xsec": 12.178
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWlnu2q_2016",
+                    "xsec": 49.997
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWlnu2q_ext1_2016",
+                    "xsec": 49.997
+                },
+                {
+                     "br": [
+                        0.25
+                    ],
+                    "dset": [
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WZ_2016",
+                    "xsec": 47.13 
+                    },
+                   {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZ_ext1_2016",
+                    "xsec": 47.13 
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased"
+            ],
+            "tag": "VV"
+        },
+        {
+            "color": 17,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZZ_2016",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WZZ_2016",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWZ_2016",
+                    "xsec": 0.1651
+                },
+                {
+                   "br": [
+                     1.0
+                   ],
+                   "dset": [
+                     "/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"  
+                   ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                   "dtag": "MC13TeV_WWW_4F_2016",
+                   "xsec": 0.2086
+                }     
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased"
+            ],
+            "tag": "ZVV"
+        },
+        {
+            "color": 831,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_s_2016",
+                    "xsec": 3.362
+                },
+                {
+                   "br": [                                                                                                                                         
+                        1.0  
+                    ], 
+                    "dset": [ 
+                        "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_at_2016",
+                    "xsec": 136.02 
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "xsec": 80.95
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_atW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_tW_2016",
+                    "xsec": 35.6
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased"
+            ],
+            "tag": "Single Top"
+        },
+        {
+            "color": 408,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	         "haa_mcbased",
+                 "haa_prod"
+            ],
+            "tag": "t#bar{t}+jets"
+        }, 
+        {
+            "color": 424,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTGJets_2016",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [
+                        0.25
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TGJets_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TGJets_ext1_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTWJetslnu_2016",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTZJets2l2nu_2016",
+                    "xsec": 0.2529
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased"
+            ],
+            "tag": "t#bar{t}+#gamma,Z,W"
+        },
+        {
+            "color": 624,
+            "data": [
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+		        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
+                    "xsec": 18610
+                },
+                {
+                    "br": [ 0.35 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+                    "xsec": 5765.4
+                },
+                {
+                    "br": [ 0.65 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 5765.4
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased",
+                "haa_prod"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                       0.3425
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WJets_2016",
+                    "xsec": 61526.7
+                },
+                {   
+                    "br": [
+                        0.6575
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WJets_ext2_2016",
+                    "xsec": 61526.7
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased",
+	    	"haa_prod"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 634,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2016",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2016",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2016",
+                    "xsec": 18810
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2016",
+                    "xsec": 1350
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt20ToInf_MuEnr_2016",
+                    "xsec": 302672
+                },
+                {
+                    "br": [
+                        0.0002
+                    ],
+                    "dset": [
+                        "/QCD_Pt_15to20_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_15to20_bcToE_2016",
+                    "xsec": 1272980000
+                },
+                {
+                    "br": [
+                        0.00059
+                    ],
+                    "dset": [
+                        "/QCD_Pt_20to30_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_20to30_bcToE_2016",
+                    "xsec": 557627000
+                },
+                {
+                    "br": [
+                        0.00255
+                    ],
+                    "dset": [
+                        "/QCD_Pt_30to80_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_30to80_bcToE_2016",
+                    "xsec": 159068000
+                },
+                {
+                    "br": [
+                        0.01183
+                    ],
+                    "dset": [
+                        "/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_80to170_bcToE_2016",
+                    "xsec": 3221000
+                },
+                {
+                    "br": [
+                        0.02492
+                    ],
+                    "dset": [
+                        "/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_170to250_bcToE_2016",
+                    "xsec": 105771
+                },
+                {
+                    "br": [
+                        0.03375
+                    ],
+                    "dset": [
+                        "/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_250toInf_bcToE_2016",
+                    "xsec": 21094.1
+                }
+            ],
+            "isdata": false,
+            "keys": [
+                "haa_mcbased"
+            ],
+            "tag": "QCD"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m20_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass20",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "resonance": 20,
+            "spimpose": true,
+            "tag": "Wh (20)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m50_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass50",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m12_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass12",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": false,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m15_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass15",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": false,
+            "tag": "Wh (15)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m25_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass25",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 5, 
+            "resonance": 25,
+            "spimpose": false,
+            "tag": "Wh (25)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m30_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass30",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 6,
+            "resonance": 30,
+            "spimpose": false,
+            "tag": "Wh (30)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m40_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass40",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3, 
+            "lstyle": 7, 
+            "resonance": 40,
+            "spimpose": false,
+            "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MinBias/sghiasis-crab_Wh_production_m60_Dec4_CMSSW8021-28028af67189b3de7224b79195bd0e1d/USER"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_Wh_amass60",
+                    "xsec": 1.37
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 8,
+            "resonance": 60,
+            "spimpose": true,
+            "tag": "Wh (60)"
+        }
+    ]
+}


### PR DESCRIPTION
Hi all, 
Please use this samples2016.json until we get Hua's proper stitching of the W+Nj and DY+Nj samples. Also, TTjets leptonic Madgraph samples are replaced with the Powheg inclusive sample .

cheers, georgia