### PR TITLE
 updated workflow for qcd control regions 

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -1678,7 +1678,7 @@ int main(int argc, char* argv[])
 	      if(ivar==0) mon.fillHisto("eventflow","all",3,weight); // MEt cut   
 	      //	      if (!passMt) continue; // only cut on MT in the Signal Region
 	      if (passMt) { 
-		QCD_region = "_fin"; 
+		QCD_region = ""; 
 		if(ivar==0) mon.fillHisto("eventflow","all",4,weight); // MT cut   
 	      }
 	      


### PR DESCRIPTION
Two modes need to be run to produce the QCD control regions:
- runQCD=false, uses only iso leptons and produces regions A(Met<25) and B(Met>25) . 
- runQCD=true, uses only non-iso leptons and produces regions C(Met<25) and D(MET>25)

One can then merge the two plotters from the above two runs.

