### PR TITLE
Further updates on MET+JES uncertainties

### DIFF
--- a/interface/BtagUncertaintyComputer.h
+++ b/interface/BtagUncertaintyComputer.h
@@ -37,6 +37,7 @@ class BTagSFUtil{
   ~BTagSFUtil();
     
   void SetSeed(int seed=0);
+  float getBTagEff(double pt, TString key);
   void modifyBTagsWithSF( bool& isBTagged, float Btag_SF = 0.98, float Btag_eff = 1.0);
 
 
@@ -64,6 +65,28 @@ BTagSFUtil::~BTagSFUtil() {
 void BTagSFUtil::SetSeed( int seed ) {
 
   rand_ = new TRandom3(seed);
+
+}
+
+float BTagSFUtil::getBTagEff(double pt, TString key) {
+  //  AN2017_018_v9: Appendix C -> Parameterization functions for the efficiency of the DeepCSV as a functions of the jet pt
+  double btag_eff = 1.;
+
+  if (key=="bLOOSE") {
+    if (pt>20 && pt<100) btag_eff=0.491+0.0191*pt-0.0004172*pt*pt+4.893*0.000001*pt*pt*pt-3.266*0.00000001*pt*pt*pt*pt+
+		      1.238*0.0000000001*pt*pt*pt*pt*pt-2.474*0.0000000000001*pt*pt*pt*pt*pt*pt+2.021*0.0000000000000001*pt*pt*pt*pt*pt*pt*pt;
+    else if (pt>=100 && pt<300) btag_eff=0.912-0.0001846*pt+2.479*0.00001*pt*pt-1.417*0.0000001*pt*pt*pt+3.617*0.0000000001*pt*pt*pt*pt-
+				  3.433*0.0000000000001*pt*pt*pt*pt*pt;
+    else if (pt>=300 && pt<1000) btag_eff=0.892-0.00014*pt+1.011*0.0000001*pt*pt;
+  } else if (key=="cLOOSE") {
+    if (pt>20 && pt<220) btag_eff=0.421-0.000563*pt+5.096*0.000001*pt*pt-1.4*0.00000001*pt*pt*pt+1.709*0.00000000001*pt*pt*pt*pt-7.627*0.000000000000001*pt*pt*pt*pt*pt;
+    else if (pt>=220 && pt<1000) btag_eff=0.383+0.000217*pt-1.997*0.00000001*pt*pt;
+  } else if (key=="lLOOSE") {
+    if (pt>20 && pt<250) btag_eff=0.2407-0.00593*pt+8.5*0.00001*pt*pt-5.658*0.0000001*pt*pt*pt+1.828*0.000000001*pt*pt*pt*pt-2.287*0.000000000001*pt*pt*pt*pt*pt;
+    else if (pt>=250 && pt<1000) btag_eff=0.0541+0.00036*pt-7.392*0.00000001*pt*pt;
+  }
+
+  return btag_eff;
 
 }
 

--- a/src/METUtils.cc
+++ b/src/METUtils.cc
@@ -42,6 +42,8 @@ double response(LorentzVector &Z, LorentzVector &MET)
 //Jet energy resoltuion, 13TeV scale factors, updated on 30/08/2018
 PhysicsObject_Jet smearedJet(const PhysicsObject_Jet &origJet, double genJetPt, int mode)
 {
+  if (mode==0) return origJet;
+
     if(genJetPt<=0) return origJet;
 
     //smearing factors are described in https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution
@@ -51,55 +53,55 @@ PhysicsObject_Jet smearedJet(const PhysicsObject_Jet &origJet, double genJetPt, 
     // Spring16_25nsV10 (80X, 2016, BCD+GH PromtReco) DATA/MC SFs 
     double ptSF(1.0), ptSF_up(1.0), ptSF_down(1.0);
     if(eta<0.5)			   {
-        ptSF=1.109;
+      //        ptSF=1.109;
         ptSF_up=ptSF+0.008;
         ptSF_down=ptSF-0.008;
     } else if(eta>=0.5 && eta<0.8) {
-        ptSF=1.138;
+      // ptSF=1.138;
         ptSF_up=ptSF+0.013;
         ptSF_down=ptSF-0.013;
     } else if(eta>=0.8 && eta<1.1) {
-        ptSF=1.114;
+      //ptSF=1.114;
         ptSF_up=ptSF+0.013;
         ptSF_down=ptSF-0.013;
     } else if(eta>=1.1 && eta<1.3) {
-        ptSF=1.123;
+      //ptSF=1.123;
         ptSF_up=ptSF+0.024;
         ptSF_down=ptSF-0.024;
     } else if(eta>=1.3 && eta<1.7) {
-        ptSF=1.084;
+      //ptSF=1.084;
         ptSF_up=ptSF+0.011;
         ptSF_down=ptSF-0.011;
     } else if(eta>=1.7 && eta<1.9) {
-        ptSF=1.082;
+      //ptSF=1.082;
         ptSF_up=ptSF+0.035;
         ptSF_down=ptSF-0.035;
     } else if(eta>=1.9 && eta<2.1) {
-        ptSF=1.140;
+      //ptSF=1.140;
         ptSF_up=ptSF+0.047;
         ptSF_down=ptSF-0.047;
     } else if(eta>=2.1 && eta<2.3) {
-        ptSF=1.067;
+      //ptSF=1.067;
         ptSF_up=ptSF+0.053;
         ptSF_down=ptSF-0.053;
     } else if(eta>=2.3 && eta<2.5) {
-        ptSF=1.177;
+      //ptSF=1.177;
         ptSF_up=ptSF+0.041;
         ptSF_down=ptSF-0.041;
     } else if(eta>=2.5 && eta<2.8) {
-        ptSF=1.364;
+      //ptSF=1.364;
         ptSF_up=ptSF+0.039;
         ptSF_down=ptSF-0.039;
     } else if(eta>=2.8 && eta<3.0) {
-        ptSF=1.857;
+      //ptSF=1.857;
         ptSF_up=ptSF+0.071;
         ptSF_down=ptSF-0.071;
     } else if(eta>=3.0 && eta<3.2) {
-        ptSF=1.328;
+      //ptSF=1.328;
         ptSF_up=ptSF+0.022;
         ptSF_down=ptSF-0.022;
     } else if(eta>=3.2 && eta<5.0) {
-        ptSF=1.16;
+      //ptSF=1.16;
         ptSF_up=ptSF+0.029;
         ptSF_down=ptSF-0.029;
     }
@@ -138,9 +140,10 @@ void computeVariation(PhysicsObjectJetCollection& jets,
         PhysicsObjectJetCollection newJets;
         LorentzVector newMET(met), jetDiff(0,0,0,0), lepDiff(0,0,0,0), unclustDiff(0,0,0,0), clusteredFlux(0,0,0,0);
         for(size_t ijet=0; ijet<jets.size(); ijet++) {
-            if(ivar==JER || ivar==JER_UP || ivar==JER_DOWN) {
+	  if(ivar==JER || ivar==JER_UP || ivar==JER_DOWN) {  
                 PhysicsObject_Jet iSmearJet=METUtils::smearedJet(jets[ijet],jets[ijet].genPt,ivar);
                 jetDiff += (iSmearJet-jets[ijet]);
+		//		if (ivar==JER && jetDiff.pt()!=0) printf("Something WRONG with variedJets[0]\n");
                 newJets.push_back( iSmearJet );
             } else if(ivar==JES_UP || ivar==JES_DOWN) {
                 double varSign=(ivar==JES_UP ? 1.0 : -1.0 );
@@ -157,6 +160,12 @@ void computeVariation(PhysicsObjectJetCollection& jets,
                 jetDiff += (iScaleJet-jets[ijet]);
                 newJets.push_back(iScaleJet);
             } else if(ivar==UMET_UP || ivar==UMET_DOWN)  clusteredFlux += jets[ijet];
+	  
+	  if(ivar==UMET_UP || ivar==UMET_DOWN || ivar==LES_UP || ivar==LES_DOWN) {    
+	    // Reset jets  
+	    PhysicsObject_Jet iScaleJet(jets[ijet]); 
+	    newJets.push_back(iScaleJet);      
+	  }
         }
 
         if(ivar==UMET_UP || ivar==UMET_DOWN || ivar==LES_UP || ivar==LES_DOWN) {


### PR DESCRIPTION
- Added parameterization for the MC efficiency of the DeepCSV as a function of the jet pt . Taken for Appendix C of AN2017_018_v9 . Needed when modify btag with SF.
- Removing jet correction itself when smearing . 
- Reseting Jets to nominal when uMET and LES uncertainties are computed...