### PR TITLE
Disable Smear Sigma and systematics for 2017 electrons

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -1116,7 +1116,8 @@ int main(int argc, char* argv[])
 		double sigma=0.0;
 #ifdef YEAR_2017
     //https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaMiniAODV2#2017_MiniAOD_V2
-    sigma = ilep.en_enSmearNrSigma;
+//    sigma = ilep.en_enSmearNrSigma;
+    sigma = 0.0;
 #else
     sigma = eScaler_.getSmearingSigma(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et,ilep.en_gainSeed,0,0);
 #endif
@@ -1129,7 +1130,8 @@ int main(int argc, char* argv[])
 	      } else {
 		double scale_corr=1.0;
 #ifdef YEAR_2017
-    scale_corr = ilep.en_enScaleValue;
+//    scale_corr = ilep.en_enScaleValue;
+    scale_corr = 1.0;
 #else
     scale_corr = eScaler_.ScaleCorrection(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et,ilep.en_gainSeed); 
 #endif
@@ -1172,7 +1174,8 @@ int main(int argc, char* argv[])
 		if(ivar==1) { //stat electron up
 		  double error_scale=0.0;
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleStatUp/ilep.E()-1;
+      //error_scale = ilep.en_enScaleStatUp/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron stat up error scale: %f\n",error_scale);
 #else
 		  error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_stat);
@@ -1182,7 +1185,8 @@ int main(int argc, char* argv[])
 		}if(ivar==2) { //stat electron down
 		  double error_scale=0.0;
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleStatDown/ilep.E()-1;
+      //error_scale = ilep.en_enScaleStatDown/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron stat down error scale: %f\n",error_scale);
 #else
       error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_stat); 
@@ -1192,7 +1196,8 @@ int main(int argc, char* argv[])
 		}if(ivar==3) { //systematic electron up
 		  double error_scale=0.0;
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleSystUp/ilep.E()-1;
+      //error_scale = ilep.en_enScaleSystUp/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron sys up error scale: %f\n",error_scale);
 #else
       error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_syst);
@@ -1202,7 +1207,8 @@ int main(int argc, char* argv[])
 		}if(ivar==4) { //systematic electron down
 		  double error_scale=0.0;
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleSystDown/ilep.E()-1;
+      //error_scale = ilep.en_enScaleSystDown/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron stat down error scale: %f\n",error_scale);
 #else
       error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_syst);
@@ -1212,7 +1218,8 @@ int main(int argc, char* argv[])
 		}if(ivar==5) { //gain switch electron up
 		  double error_scale=0.0;
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleGainUp/ilep.E()-1;
+      //error_scale = ilep.en_enScaleGainUp/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron gain up error scale: %f\n",error_scale);
 #else
       error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_gain);
@@ -1222,7 +1229,8 @@ int main(int argc, char* argv[])
 		}if(ivar==6) { //gain switch electron down
 		  double error_scale=0.0;  
 #ifdef YEAR_2017
-      error_scale = ilep.en_enScaleGainDown/ilep.E()-1;
+      //error_scale = ilep.en_enScaleGainDown/ilep.E()-1;
+      error_scale = 0.0;
 //      printf("Electron gain down error scale: %f\n",error_scale);
 #else	      
       error_scale = eScaler_.ScaleCorrectionUncertainty(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,bit_gain);      
@@ -1232,7 +1240,8 @@ int main(int argc, char* argv[])
 		}if(ivar==7) { //rho resolution Electron up
 		  double smearValue = 1.0;
 #ifdef YEAR_2017
-      smearValue = ilep.en_enSigmaRhoUp/ilep.E();
+      //smearValue = ilep.en_enSigmaRhoUp/ilep.E();
+      smearValue = 1.0;
 //      printf("Electron rho up smear value: %f\n",smearValue);
 #else
       double sigma = eScaler_.getSmearingSigma(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,1,0);
@@ -1245,7 +1254,8 @@ int main(int argc, char* argv[])
 		}if(ivar==8) { //rho resolution Electron down
 		  double smearValue = 1.0;       
 #ifdef YEAR_2017
-      smearValue = ilep.en_enSigmaRhoDown/ilep.E();
+      //smearValue = ilep.en_enSigmaRhoDown/ilep.E();
+      smearValue = 1.0;
 //      printf("Electron rho down smear value: %f\n",smearValue);
 #else
       double sigma = eScaler_.getSmearingSigma(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,-1,0);
@@ -1258,7 +1268,8 @@ int main(int argc, char* argv[])
 		}if(ivar==9) { //phi resolution Electron down
 		  double smearValue = 1.0;
 #ifdef YEAR_2017
-      smearValue = ilep.en_enSigmaPhiDown/ilep.E();
+      //smearValue = ilep.en_enSigmaPhiDown/ilep.E();
+      smearValue = 1.0;
 //      printf("Electron phi down smear value: %f\n",smearValue);
 #else
       double sigma = eScaler_.getSmearingSigma(phys.run,(fabs(ilep.en_EtaSC)<=1.447),ilep.en_R9, ilep.en_EtaSC, et, ilep.en_gainSeed,0,-1);


### PR DESCRIPTION
As above. Make sure 2017 Ntuples have corresponding values before enabling them.