### PR TITLE
Fix on 2017 low mass DY samples weights and 2018 json file

### DIFF
--- a/bin/common/runPlotter.cc
+++ b/bin/common/runPlotter.cc
@@ -602,7 +602,10 @@ void SavingToFile(JSONWrapper::Object& Root, std::string RootDir, TFile* OutputF
 	   Weight=iLumi/fileList.size();
 	   // Overwrite weight for W+Nj and DY+Nj samples
 	   if (dirProc.find("W#rightarrow l#nu")!=std::string::npos) Weight=iLumi;
-	   if (dirProc.find("Z#rightarrow ll")!=std::string::npos) Weight=iLumi;  
+	   if (dirProc.find("Z#rightarrow ll")!=std::string::npos) {
+        if ((Samples[j])["dtag"].toString().find("10to50")!=std::string::npos && (Samples[j])["dtag"].toString().find("2017")!=std::string::npos) ; //except for 2017 low-mass DY samples
+        else Weight=iLumi;
+     }
 	   //	   if (Process[i].getStringFromKeyword(matchingKeyword, "tag", "W#rightarrow l#nu")) Weight=iLumi;
 	 } else {Weight=1.0;}  
 	 //	 {Weight= iLumi/fileList.size();}else{Weight=1.0;}

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -972,7 +972,9 @@ int main(int argc, char* argv[])
 	    { xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(0, ev.lheNJets, is2017MC); }
           else if( isMC_DY ) {
 	    if (string(url.Data()).find("10to50")  != string::npos)
-	      { xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(1, ev.lheNJets, is2017MC); }
+	      { 
+          if (is2016MC) xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(1, ev.lheNJets, is2017MC);        
+        }
             else
 	      { xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(2, ev.lheNJets, is2017MC); }
           }

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -207,7 +207,7 @@
             "tag": "data"
         },
         {
-            "color": 595,
+            "color": 852,
             "data": [
                 {
                     "br": [
@@ -600,7 +600,7 @@
                 "haa_mcbased",
                 "haa_ztoll"
             ],
-            "tag": "DYJets"
+            "tag": "Z#rightarrow ll"
         },
         {
             "color": 622,


### PR DESCRIPTION
1. Fix on 2017 low mass DY samples weights in runhaaAnalysis.cc and runPlotter.cc
2. Update in 2018 json file the tag of DY sample