### PR TITLE
Using Fall17v1 IDs and disable a met filter to reduce 2017 NTuple production time

### DIFF
--- a/interface/MacroUtils.h
+++ b/interface/MacroUtils.h
@@ -136,7 +136,7 @@ namespace utils
     typedef std::vector<TGraph *> PuShifter_t;
     enum PuShifterTypes {PUDOWN,PUUP};
     utils::cmssw::PuShifter_t getPUshifters(std::vector< float > &Lumi_distr, float puUnc);
-    Float_t getEffectiveArea(int id, float eta,TString isoSum="");
+    Float_t getEffectiveArea(int id, float eta, Int_t yearBits, TString isoSum="");
 //    double relIso(llvvLepton lep, double rho);
 
     // Single muon trigger efficiency 

--- a/interface/PatUtils.h
+++ b/interface/PatUtils.h
@@ -79,7 +79,7 @@ namespace patUtils
    namespace llvvPhotonId { enum PhotonId  {Loose, Medium, Tight}; }
    namespace llvvElecIso{ enum ElecIso {Veto, Loose, Medium, Tight}; }
    namespace llvvMuonIso{ enum MuonIso {Loose,Tight, H4lWP, TightBoosted, TightAndTkRelatBoosted}; }
-   namespace CutVersion { enum CutSet {Spring15Cut25ns, ICHEP16Cut, Moriond17Cut, Fall17v2}; }
+   namespace CutVersion { enum CutSet {Spring15Cut25ns, ICHEP16Cut, Moriond17Cut, Fall17v1, Fall17v2}; }
 
    unsigned int GainSeed (pat::Electron &electron, const EcalRecHitCollection* recHits);
    unsigned int GainSeed (pat::Photon &photon, const EcalRecHitCollection* recHits);
@@ -87,9 +87,9 @@ namespace patUtils
    bool passId (pat::Electron& el,  reco::Vertex& vtx, int IdLevel, int cutVersion, bool is2016=true); // Old PHYS14 ID
    bool passId (pat::Muon&     mu,  reco::Vertex& vtx, int IdLevel, int cutVersion);
    bool passId (pat::Photon& photon,  double rho, int IdLevel);
-   float relIso(patUtils::GenericLepton& lep, double rho);
+   float relIso(patUtils::GenericLepton& lep, double rho, Int_t yearBits);
    bool passIso (VersionedPatElectronSelector id, pat::Electron& el);
-   bool passIso(pat::Electron& el,  int IsoLevel, int cutVersion, float* relIso_el, double rho=0.0 ); // Old PHYS15 Iso
+   bool passIso(pat::Electron& el,  int IsoLevel, int cutVersion, float* relIso_el, Int_t yearBits, double rho=0.0); // Old PHYS15 Iso
    bool passIso(pat::Muon&     mu,  int IsoLevel, int cutVersion, float* relIso_mu, float* trkrelIso_);
    bool passIso(pat::Muon& mu, int IsoLevel, int cutVersion, std::vector<pat::PackedCandidate> thePats, pat::MuonCollection muons, reco::Vertex& vertex );
    bool passPhotonTrigger(fwlite::Event &ev, float &triggerThreshold, float &triggerPrescale, float& triggerThresholdHigh);

--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -931,11 +931,11 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	
     }
  
-    if(is2017 || is2018){
-	edm::Handle< bool > passecalBadCalibFilterUpdate;
-	event.getByToken(ecalBadCalibFilterUpdate_token,passecalBadCalibFilterUpdate);
-	passMETFilters &= (*passecalBadCalibFilterUpdate);
-    }
+//    if(is2017 || is2018){
+//	edm::Handle< bool > passecalBadCalibFilterUpdate;
+//	event.getByToken(ecalBadCalibFilterUpdate_token,passecalBadCalibFilterUpdate);
+//	passMETFilters &= (*passecalBadCalibFilterUpdate);
+//    }
   
     if(!passMETFilters) return;
    //   if( metFilterValue!=0 ) continue;	 //Note this must also be applied on MC
@@ -1068,7 +1068,8 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	 if (pt_ < 15.) continue;
 
 	 bool passId;
-	 if(is2017 || is2018) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v2);
+	 if(is2018) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v2);
+	 else if(is2017) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v1);
 	 else passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut);
 	 if(!passId) continue;
 
@@ -1095,14 +1096,17 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	 ev.en_neutralHadIso[ev.en] = pfIso.sumNeutralHadronEt;
 	 */
          float relIso_el = -1;
-	 if(is2017 || is2018){
+	 if(is2018){
 	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v2);
 	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v2);
+	 }else if(is2017){
+	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v1);
+	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v1);
 	 } else{ //2016
 	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut);
 	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::ICHEP16Cut);
 	 }
-	 ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, &relIso_el, rho) ;
+	 ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, &relIso_el, rho, (is2017 << 0) | (is2018 << 1)) ;
          ev.en_relIso[ev.en] = relIso_el;
 
 	 const EcalRecHitCollection* recHits = (el.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();

--- a/src/MacroUtils.cc
+++ b/src/MacroUtils.cc
@@ -317,21 +317,35 @@ namespace utils
     
 
     //
-    Float_t getEffectiveArea(int id,float eta,TString isoSum)
+    Float_t getEffectiveArea(int id,float eta,Int_t yearBits,TString isoSum)
     {
+      bool is2017 = yearBits & 0x01;
+      bool is2018 = (yearBits >> 1) & 0x01;
+      bool is2016 = !(is2017 || is2018);
       Float_t Aeff(1.0);
 
       if(abs(id)==11){ // electron
 	//Summer16 EA (Recommended for Moriond) : https://indico.cern.ch/event/482673/contributions/2187022/attachments/1282446/1905912/talk_electron_ID_spring16.pdf
-	
-        if(fabs(eta)<1.0)				Aeff=0.1703;
-        else if(fabs(eta)>1.0 && fabs(eta)<1.479)	Aeff=0.1715;
-        else if(fabs(eta)>1.479 && fabs(eta)<2.0)	Aeff=0.1213;
-        else if(fabs(eta)>2.0 && fabs(eta)<2.2)		Aeff=0.1230;
-        else if(fabs(eta)>2.2 && fabs(eta)<2.3)		Aeff=0.1635;
-        else if(fabs(eta)>2.3 && fabs(eta)<2.4)		Aeff=0.1937;
-        else						Aeff=0.2393;
-       }
+	if(is2016){
+          if(fabs(eta)<1.0)				Aeff=0.1703;
+	  else if(fabs(eta)>1.0 && fabs(eta)<1.479)	Aeff=0.1715;
+          else if(fabs(eta)>1.479 && fabs(eta)<2.0)	Aeff=0.1213;
+          else if(fabs(eta)>2.0 && fabs(eta)<2.2)	Aeff=0.1230;
+          else if(fabs(eta)>2.2 && fabs(eta)<2.3)	Aeff=0.1635;
+          else if(fabs(eta)>2.3 && fabs(eta)<2.4)	Aeff=0.1937;
+          else						Aeff=0.2393;
+	}
+	//https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_94X.txt
+        else if(is2017 || is2018){
+          if(fabs(eta)<1.0)				Aeff=0.1440;
+	  else if(fabs(eta)>1.0 && fabs(eta)<1.479)	Aeff=0.1562;
+          else if(fabs(eta)>1.479 && fabs(eta)<2.0)	Aeff=0.1032;
+          else if(fabs(eta)>2.0 && fabs(eta)<2.2)	Aeff=0.0859;
+          else if(fabs(eta)>2.2 && fabs(eta)<2.3)	Aeff=0.1116;
+          else if(fabs(eta)>2.3 && fabs(eta)<2.4)	Aeff=0.1321;
+          else						Aeff=0.1654;
+        }
+      }
 
       else if(abs(id)==22){ // photon
         // Spring16 EA (Recommended for Moriond) : https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2#Selection_implementation_details

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -367,6 +367,36 @@ namespace patUtils
             }
       break;
 
+    //https://twiki.cern.ch/twiki/bin/view/CMS/EgammaRunIIRecommendations#Example_accessing_IDs
+    case CutVersion::Fall17v1 :
+	switch(IdLevel){
+	  case llvvElecId::Loose :
+	    if(el.electronID("cutBasedElectronID-Fall17-94X-V1-loose")) return true;
+	  break;
+
+	  case llvvElecId::Medium :
+	    if(el.electronID("cutBasedElectronID-Fall17-94X-V1-medium")) return true;
+	  break;
+
+	  case llvvElecId::Tight :
+	    if(el.electronID("cutBasedElectronID-Fall17-94X-V1-tight")) return true;
+	  break;
+
+	  case llvvElecId::wp80MVA :
+	    if(el.electronID("mvaEleID-Fall17-iso-V1-wp80")) return true;
+	  break;
+
+	  case llvvElecId::wp90MVA :
+	    if(el.electronID("mvaEleID-Fall17-iso-V1-wp90")) return true;
+	  break;
+
+	  default:
+	    printf("FIXME ElectronId llvvElecId::%i is unkown\n", IdLevel);
+	    return false;
+	    break;
+	}
+	break;
+    
     case CutVersion::Fall17v2 :
 	switch(IdLevel){
 	  case llvvElecId::Loose :
@@ -548,13 +578,13 @@ namespace patUtils
     double eta=photon.superCluster()->eta();
 
     float chIso = photon.chargedHadronIso();
-    float chArea = utils::cmssw::getEffectiveArea(22,eta,"chIso");
+    float chArea = utils::cmssw::getEffectiveArea(22,eta,0,"chIso");
 
     float nhIso = photon.neutralHadronIso();
-    float nhArea = utils::cmssw::getEffectiveArea(22,eta,"nhIso");
+    float nhArea = utils::cmssw::getEffectiveArea(22,eta,0,"nhIso");
 
     float gIso = photon.photonIso();
-    float gArea = utils::cmssw::getEffectiveArea(22,eta,"gIso");
+    float gArea = utils::cmssw::getEffectiveArea(22,eta,0,"gIso");
 
     bool barrel = (fabs(eta) <= 1.479);
     bool endcap = (!barrel && fabs(eta) < 2.5);
@@ -633,7 +663,7 @@ namespace patUtils
     return false;
   }
 
-  float relIso(patUtils::GenericLepton& lep, double rho){
+  float relIso(patUtils::GenericLepton& lep, double rho, Int_t yearBits){
 
     int lid=lep.pdgId();
     float relIso = 0.0;
@@ -659,7 +689,7 @@ namespace patUtils
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / lep.el.pt();
       }
       else {
-	float effArea = utils::cmssw::getEffectiveArea(11,lep.el.superCluster()->eta());
+	float effArea = utils::cmssw::getEffectiveArea(11,lep.el.superCluster()->eta(),yearBits);
 	relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / lep.el.pt();
       }
 
@@ -676,7 +706,7 @@ namespace patUtils
     return true; // Isolation is now embedded into the ID.
   }
 
-  bool passIso(pat::Electron& el, int IsoLevel, int cutVersion, float* relIso_el, double rho ){
+  bool passIso(pat::Electron& el, int IsoLevel, int cutVersion, float* relIso_el, Int_t yearBits, double rho){
          //https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Spring15_selection_25ns
 	  float  chIso   = el.pfIsolationVariables().sumChargedHadronPt;
           float  nhIso   = el.pfIsolationVariables().sumNeutralHadronEt;
@@ -689,7 +719,7 @@ namespace patUtils
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-0.5*puchIso)) / el.pt();
 	  }
 	  else {
-	    float effArea = utils::cmssw::getEffectiveArea(11,el.superCluster()->eta());
+	    float effArea = utils::cmssw::getEffectiveArea(11,el.superCluster()->eta(),yearBits);
 	    relIso  = (chIso + TMath::Max(0.,nhIso+gIso-rho*effArea)) / el.pt();
 	  }
           *relIso_el = relIso;

--- a/test/fullAnalysis_cfg_2017.py.templ
+++ b/test/fullAnalysis_cfg_2017.py.templ
@@ -52,7 +52,7 @@ process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
 
 #rerun energy correction for electrons
 setupEgammaPostRecoSeq(process,
-    runVID=True, #if you want the Fall17V2 IDs, set this to True or remove (default is True)
+    runVID=False, #if you want the Fall17V2 IDs, set this to True or remove (default is True)
     era='2017-Nov17ReReco')
 #a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
 
@@ -103,7 +103,7 @@ process.TFileService = cms.Service("TFileService",
 )
 
 process.p = cms.Path( 
-    process.ecalBadCalibReducedMINIAODFilter *
+#    process.ecalBadCalibReducedMINIAODFilter *
     process.fullPatMetSequence *
     process.fullPatMetSequenceModifiedMET *
     process.egammaPostRecoSeq *

--- a/test/haa4b/runlocal_test_2017.py
+++ b/test/haa4b/runlocal_test_2017.py
@@ -7,11 +7,11 @@ from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 #load run conditions
 #process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -55,7 +55,7 @@ process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
      )
 #rerun energy correction for electrons
 setupEgammaPostRecoSeq(process,
-    runVID=True, #saves CPU time by not needlessly re-running VID
+    runVID=False, #saves CPU time by not needlessly re-running VID
     era='2017-Nov17ReReco')
 #a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
 
@@ -147,7 +147,7 @@ process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 #process.p = cms.Path(process.dump)
 process.p = cms.Path( 
 #    process.fullPatMetSequenceTEST *
-    process.ecalBadCalibReducedMINIAODFilter *
+#    process.ecalBadCalibReducedMINIAODFilter *
     process.fullPatMetSequence *
     process.fullPatMetSequenceModifiedMET *
     process.egammaPostRecoSeq *


### PR DESCRIPTION
1. Switch Electron IDs from Fall17v2 to Fall17v1 for 2017 analysis;
2. Disable the MET Filter: ecalBadCalibReducedMINIAODFilter added last week, which takes long time to run the extra recipe needed;
3. Update effective area for 2017 and 2018 analysis when calculating electron Isolation.