### PR TITLE
Add S/B and significance info in the eventflow table

### DIFF
--- a/src/MacroUtils.cc
+++ b/src/MacroUtils.cc
@@ -481,7 +481,8 @@ namespace utils
     }
     
     double power = floor(log10(value));
-    if(power<=-3)     {power=power+3;}
+    //if(power<=-3)     {power=power+3;}
+    if(power<=-2)     {power=power;}
     else if(power>=2) {power=power-2;}
     else              {power=0;}
     

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -1548,9 +1548,9 @@
                         0.2132
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass20_2016",
                     "xsec": 1.37
                 },
@@ -1559,9 +1559,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass20_2016",
                     "xsec": 0.8594 
                 }
@@ -1589,9 +1589,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass50_2016",
                     "xsec": 1.37
                 },
@@ -1600,9 +1600,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass50_2016",
                     "xsec": 0.8594 
                 }
@@ -1630,9 +1630,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-12_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass12_2016",
                     "xsec": 1.37
                 },
@@ -1641,9 +1641,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-12_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass12_2016",
                     "xsec": 0.8594 
                 }
@@ -1671,10 +1671,21 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-15_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass15_2016",
+                    "xsec": 1.37
+                },
+                {
+                    "br": [
+                        0.067316
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass15_2016",
                     "xsec": 1.37
                 }
             ],
@@ -1701,9 +1712,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-25_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass25_2016",
                     "xsec": 1.37
                 },
@@ -1712,9 +1723,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-25_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass25_2016",
                     "xsec": 0.8594 
                 }
@@ -1742,9 +1753,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-30_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass30_2016",
                     "xsec": 1.37
                 },
@@ -1753,9 +1764,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-30_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass30_2016",
                     "xsec": 0.8594 
                 }
@@ -1783,9 +1794,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-40_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass40_2016",
                     "xsec": 1.37
                 },
@@ -1794,9 +1805,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-40_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass40_2016",
                     "xsec": 0.8594 
                 }
@@ -1824,9 +1835,9 @@
                         0.2132 
                     ],
                     "dset": [
-                        "/SUSYWHToAA_AATo4B_M-60_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass60_2016",
                     "xsec": 1.37
                 },
@@ -1835,9 +1846,9 @@
                         0.067316
                     ],
                     "dset": [
-                        "/SUSYZHToAA_AATo4B_M-60_TuneCUETP8M1_13TeV_madgraph_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
                     ],
-                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass60_2016",
                     "xsec": 0.8594 
                 }


### PR DESCRIPTION
1. Add S/B and significance info in the eventflow table at amass=60;
2. Update 2016 signal datasets to the new samples