### PR TITLE
Decouple 2017 trigger path

### DIFF
--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -815,8 +815,11 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
    if(!tr.isValid()  )return;
    
    // float triggerPrescale(1.0),triggerThreshold(0), triggerThresholdHigh(99999);
-   bool mumuTrigger(false); bool muTrigger(false); bool muTrigger2(false);
-   bool eeTrigger(false); bool eeTrigger2(false); bool eTrigger(false); bool eTrigger2(false); bool emuTrigger(false);
+   bool eTrigger(false), eTrigger2(false); 
+   bool muTrigger(false), muTrigger2(false);
+   bool eeTrigger(false), eeTrigger2(false); 
+   bool mumuTrigger(false), mumuTrigger2(false); 
+   bool emuTrigger(false), emuTrigger2(false);
    bool highPTeTrigger(false);
    
    if(is2018){
@@ -830,16 +833,18 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
       emuTrigger         = utils::passTriggerPatterns(tr,"HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*");
    }else if(is2017){
       //https://indico.cern.ch/event/682891/contributions/2810364/attachments/1570825/2820752/20171206_CMSWeek_MuonHLTReport_KPLee_v3_4.pdf
-      mumuTrigger        = utils::passTriggerPatterns(tr,"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*","HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*","HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*");
-      muTrigger          = utils::passTriggerPatterns(tr,"HLT_IsoMu24_eta2p1_v*","HLT_IsoMu27_v*","HLT_IsoMu24_v*");
-      // For 2017, muTrigger2 is always set to True
+      mumuTrigger        = utils::passTriggerPatterns(tr,"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*");
+      mumuTrigger2	 = utils::passTriggerPatterns(tr,"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*");
+      muTrigger          = utils::passTriggerPatterns(tr,"HLT_IsoMu27_v*");
+      muTrigger2	 = utils::passTriggerPatterns(tr,"HLT_IsoMu24_eta2p1_v*","HLT_IsoMu24_v*");
       //   https://twiki.cern.ch/twiki/bin/view/CMS/Egamma2017DataRecommendations#E/gamma%20Trigger%20Recomendations
       eeTrigger          = utils::passTriggerPatterns(tr,"HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*");// isolation version
-      eeTrigger2         = utils::passTriggerPatterns(tr,"HLT_DoubleEle33_CaloIdL_MW_v*","HLT_DoubleEle25_CaloIdL_MW_v*"); // non isolation version
+      eeTrigger2         = utils::passTriggerPatterns(tr,"HLT_DoubleEle33_CaloIdL_MW_v*"); // non isolation version
       // 2017 RunB and C single electron trigger needs special treatment, see below
       eTrigger           = utils::passTriggerPatterns(tr,"HLT_Ele32_WPTight_Gsf_v*"); //"HLT_Ele32_WPTight_Gsf_L1DoubleEG_v*";
       //eTrigger2          = utils::passTriggerPatterns(tr,"HLT_Ele35_WPTight_Gsf_v*");
-      emuTrigger         = utils::passTriggerPatterns(tr,"HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*") || utils::passTriggerPatterns(tr,"HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*");
+      emuTrigger         = utils::passTriggerPatterns(tr,"HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*");
+      emuTrigger2	 = utils::passTriggerPatterns(tr,"HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*");
    } else{
       mumuTrigger        = utils::passTriggerPatterns(tr, "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*", "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*" , "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");
       //   muTrigger          = utils::passTriggerPatterns(tr, "HLT_IsoMu22_v*","HLT_IsoTkMu22_v*", "HLT_IsoMu24_v*", "HLT_IsoTkMu24_v*");
@@ -891,7 +896,7 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
    }
 #endif
 
-   ev.hasTrigger  = ( mumuTrigger||muTrigger||muTrigger2||eeTrigger||eeTrigger2||highPTeTrigger||eTrigger||eTrigger2||emuTrigger );
+   ev.hasTrigger  = ( mumuTrigger||mumuTrigger2||muTrigger||muTrigger2||eeTrigger||eeTrigger2||highPTeTrigger||eTrigger||eTrigger2||emuTrigger||emuTrigger2 );
    //ev.hasTrigger  = ( muTrigger||eTrigger||emuTrigger ); 
    
    ev.triggerType = ( mumuTrigger  << 0 )
@@ -902,7 +907,9 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
      | ( emuTrigger << 5 ) 
      | ( muTrigger2 << 6 )
      | ( eTrigger2 << 7 )
-     | ( eeTrigger2 << 8 );
+     | ( eeTrigger2 << 8 )
+     | ( mumuTrigger2 << 9 )
+     | ( emuTrigger2 << 10 );
    
    //if(!isMC__ && !ev.hasTrigger) return; // skip the event if no trigger, only for Data
    if(!ev.hasTrigger) return; // skip the event if no trigger, for both Data and MC

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -1556,7 +1556,7 @@
                 },
 		{
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1596,7 +1596,7 @@
                 },
 		            {
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1636,7 +1636,7 @@
                 },
 		            {
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1676,7 +1676,7 @@
                 },
                 {
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1716,7 +1716,7 @@
                 },
 		{
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1756,7 +1756,7 @@
                 },
 		{
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1796,7 +1796,7 @@
                 },
 		 {
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
@@ -1836,7 +1836,7 @@
                 },
 		  {
                     "br": [
-                        0.10
+                        0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"


### PR DESCRIPTION
1. Decouple 2017 trigger path;
2. Update 2016 ZH signal samples branch ratio with high precision.