### PR TITLE
Reorder the signal datasets, update HtCondor implementation and a few optimizations

### DIFF
--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -447,7 +447,6 @@ class AllInfo_t
     // Handle empty bins
     void HandleEmptyBins(string histoName);
 
-    void debug(TString histoName, string funcName);
 };
 
 
@@ -1496,9 +1495,6 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 
         TH1* h = ch->second.shapes[histoName.Data()].histo();
 	if (!h) continue;
-	//if( ch->first.find("e_A_SR_3b") != string::npos){
-	//  printf("ShowShape: Name: %s_%s, integral: %f\n",ch->first.c_str(),histoName.Data(),h->Integral());
-	//}
         //if(process.Contains("SOnly_S") ) h->Scale(10);  
         if(it->first=="total"){
           //double Uncertainty = std::max(0.0, ch->second.shapes[histoName.Data()].getScaleUncertainty() / h->Integral() );;
@@ -1928,7 +1924,6 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       //save canvas
       LabelText.ReplaceAll(" ","_"); 
       // c[I]->SaveAs(SaveName+"_Shape.png");
-      c[I]->SaveAs(LabelText+"_Shape.png");
       c[I]->SaveAs(LabelText+"_Shape.pdf");
       c[I]->SaveAs(LabelText+"_Shape.C");
       delete c[I];
@@ -2802,10 +2797,6 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 	  }else{
 	    shapeInfo.uncShape[varName.Data()]->Add(hshape);
 	  }
-
-	  //if( string(histoName.Data()).find("e_A_SR_3b") != string::npos){
-	  //  printf("GetShapeFromFile: Name: %s, integral: %f\n",histoName.Data(),hshape->Integral());
-	  //}
         }
       }
     }
@@ -2927,23 +2918,6 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 
     //recompute total background
     computeTotalBackground();
-  }
-
-  void AllInfo_t::debug(TString histoName, string funcName){
-    sortProc();
-    for(unsigned int p=0;p<sorted_procs.size();p++){
-      string procName = sorted_procs[p];
-      std::map<string, ProcessInfo_t>::iterator it=procs.find(procName);
-      if(it==procs.end())continue;
-      for(std::map<string, ChannelInfo_t>::iterator ch = it->second.channels.begin(); ch!=it->second.channels.end(); ch++){
-	if(ch->second.shapes.find(histoName.Data())==(ch->second.shapes).end())continue;
-	TH1* h = ch->second.shapes[histoName.Data()].histo();
-	if (!h) continue;
-	if( ch->first.find("e_A_SR_3b") != string::npos){
-	  printf("%s: Name: %s_%s, integral: %f\n",funcName.c_str(),ch->first.c_str(),histoName.Data(),h->Integral());
-	}
-      }
-    }
   }
 
 

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -2191,7 +2191,6 @@ int main(int argc, char* argv[])
 		    }
 		    //btsfutil.modifyBTagsWithSF(hasCSVtagLDown, btagReaderLoose.eval_auto_bounds("down", BTagEntry::FLAV_B ,
 		    //									  vJets[ijet].eta(), vJets[ijet].pt()), beff); hasCSVtagL=hasCSVtagLDown;
-		    std::cout << "tag_cat: " << tag_cat << ", bSFLoose: " << bSFLoose << ", bSFMedium: " << bSFMedium << ", beffLoose: " << beffLoose << ", beffMedium: " << beffMedium << std::endl;
 		    btsfutil.applySF2WPs(hasCSVtagLDown, hasCSVtagMDown, bSFLoose, bSFMedium, beffLoose, beffMedium);
 		    hasCSVtagL=hasCSVtagLDown; hasCSVtagM=hasCSVtagMDown;
 		  } else {
@@ -2789,7 +2788,6 @@ int main(int argc, char* argv[])
 	    mon.fillHisto("dmmin",tags,dm, weight);
 	    // BDT
 	    mon.fillHisto("bdt", tags, mvaBDT, weight);
-//	    std::cout << "btd: " << mvaBDT << ", filled into bdt, event: " << ev.event << ", lumi: " << ev.lumi << std::endl;
 	      
 	    
 	    //##############################################################################
@@ -2832,7 +2830,6 @@ int main(int argc, char* argv[])
 	    //scan the BDT cut and fill the shapes
 	    for(unsigned int index=0;index<optim_Cuts1_bdt.size();index++){
 	      if(mvaBDT>optim_Cuts1_bdt[index]){
-//	        std::cout << "btd: " << mvaBDT << ", cut index: " << index << ", cut: " << optim_Cuts1_bdt[index] << ", filled into bdt shapes, event: " << ev.event << ", lumi: " << ev.lumi << std::endl;
 		mon.fillHisto(TString("bdt_shapes")+varNames[ivar],tags,index, mvaBDT,weight);
 		if (ivar==0) {
 		  mon.fillHisto(TString("higgsMass_shapes")+varNames[ivar],tags,index, allHadronic.mass(),weight);  

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -770,8 +770,8 @@ int main(int argc, char* argv[])
 	mon.addHistogram( new TH2F (TString("higgsMass_shapes")+varNames[ivar],";cut index;m_{h} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(), 40,0.,800.) );
 	mon.addHistogram( new TH2F (TString("higgsPt_shapes")+varNames[ivar],";cut index;p_{T}^{h} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(), 30,0.,500.));
 	mon.addHistogram( new TH2F (TString("ht_shapes")+varNames[ivar],";cut index;H_{T} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),40,0.,800.) );
-	mon.addHistogram( new TH2F (TString("pfmet_shapes")+varNames[ivar],";cut index;E_{T}^{miss} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),100,0.,800.) );
-	mon.addHistogram( new TH2F (TString("mtw_shapes")+varNames[ivar],";cut index;#it{m}_{T}^{W} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),80,0.,800.) );
+	mon.addHistogram( new TH2F (TString("pfmet_shapes")+varNames[ivar],";cut index;E_{T}^{miss} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),50,0.,400.) );
+	mon.addHistogram( new TH2F (TString("mtw_shapes")+varNames[ivar],";cut index;#it{m}_{T}^{W} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),40,0.,400.) );
 	mon.addHistogram( new TH2F (TString("ptw_shapes")+varNames[ivar],";cut index;#it{p}_{T}^{W} [GeV];Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),30,0.,500.) );
 	mon.addHistogram( new TH2F (TString("dphiWh_shapes")+varNames[ivar],";cut index;#Delta#it{#phi}(#it{W},h);Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),20,0,TMath::Pi()) );
 	mon.addHistogram( new TH2F (TString("dRave_shapes")+varNames[ivar],";cut index;#Delta R(b,b)_{ave};Events",optim_Cuts1_bdt.size(),0,optim_Cuts1_bdt.size(),50,0.,5.));
@@ -2191,6 +2191,7 @@ int main(int argc, char* argv[])
 		    }
 		    //btsfutil.modifyBTagsWithSF(hasCSVtagLDown, btagReaderLoose.eval_auto_bounds("down", BTagEntry::FLAV_B ,
 		    //									  vJets[ijet].eta(), vJets[ijet].pt()), beff); hasCSVtagL=hasCSVtagLDown;
+		    std::cout << "tag_cat: " << tag_cat << ", bSFLoose: " << bSFLoose << ", bSFMedium: " << bSFMedium << ", beffLoose: " << beffLoose << ", beffMedium: " << beffMedium << std::endl;
 		    btsfutil.applySF2WPs(hasCSVtagLDown, hasCSVtagMDown, bSFLoose, bSFMedium, beffLoose, beffMedium);
 		    hasCSVtagL=hasCSVtagLDown; hasCSVtagM=hasCSVtagMDown;
 		  } else {
@@ -2788,6 +2789,7 @@ int main(int argc, char* argv[])
 	    mon.fillHisto("dmmin",tags,dm, weight);
 	    // BDT
 	    mon.fillHisto("bdt", tags, mvaBDT, weight);
+//	    std::cout << "btd: " << mvaBDT << ", filled into bdt, event: " << ev.event << ", lumi: " << ev.lumi << std::endl;
 	      
 	    
 	    //##############################################################################
@@ -2830,6 +2832,7 @@ int main(int argc, char* argv[])
 	    //scan the BDT cut and fill the shapes
 	    for(unsigned int index=0;index<optim_Cuts1_bdt.size();index++){
 	      if(mvaBDT>optim_Cuts1_bdt[index]){
+//	        std::cout << "btd: " << mvaBDT << ", cut index: " << index << ", cut: " << optim_Cuts1_bdt[index] << ", filled into bdt shapes, event: " << ev.event << ", lumi: " << ev.lumi << std::endl;
 		mon.fillHisto(TString("bdt_shapes")+varNames[ivar],tags,index, mvaBDT,weight);
 		if (ivar==0) {
 		  mon.fillHisto(TString("higgsMass_shapes")+varNames[ivar],tags,index, allHadronic.mass(),weight);  

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -1540,87 +1540,7 @@
 	         "haa_mcbased"	
             ],
              "tag": "Vh(bb)"
-       },
-       {
-            "data": [
-                {
-                    "br": [
-                        0.3257
-                    ],
-                    "dset": [
-			"/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mcRun2_asymptotic_v3",
-                    "dtag": "MC13TeV_Wh_amass20_2016",
-                    "xsec": "1.37*0.61"
-                },
-		{
-                    "br": [
-                        0.10099
-                    ],
-                    "dset": [
-			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mcRun2_asymptotic_v3",
-                    "dtag": "MC13TeV_Zh_amass20_2016",
-                    "xsec": "0.8594*0.7435"
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": false,
-            "issignal": true,
-            "keys": [
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 1,
-            "lwidth": 3,
-	    "lstyle":2,
-            "resonance": 20,
-            "spimpose": true,
-            "tag": "Wh (20)"
-        },
-        {
-            "data": [
-                {
-                    "br": [
-                        0.3257
-                    ],
-                    "dset": [
-			"/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mcRun2_asymptotic_v3",
-                    "dtag": "MC13TeV_Wh_amass50_2016",
-                    "xsec": "1.37*0.61"
-                },
-		            {
-                    "br": [
-                        0.10099
-                    ],
-                    "dset": [
-			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mcRun2_asymptotic_v3",
-                    "dtag": "MC13TeV_Zh_amass50_2016",
-                    "xsec": "0.8594*0.7435"
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": true,
-            "issignal": true,
-            "keys": [
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 2,
-            "lwidth": 3,
-            "lstyle": 2,
-            "resonance": 50,
-            "spimpose": false,
-            "tag": "Wh (50)"
-        },
+	 },
         {
             "data": [
                 {
@@ -1658,7 +1578,7 @@
             "lwidth": 3,
             "lstyle": 3,
             "resonance": 12,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (12)"
         },
         {
@@ -1700,6 +1620,46 @@
             "resonance": 15,
             "spimpose": false,
             "tag": "Wh (15)"
+        },
+       {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass20_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass20_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+	    "lstyle":2,
+            "resonance": 20,
+            "spimpose": false,
+            "tag": "Wh (20)"
         },
         {   
             "data": [
@@ -1820,6 +1780,46 @@
             "resonance": 40,
             "spimpose": false,
             "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass50_2016",
+                    "xsec": "1.37*0.61"
+                },
+		            {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass50_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
         },
         {
             "data": [

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -1087,87 +1087,6 @@
                         0.2132
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass20_2017",
-                    "xsec": 1.37
-                },
-                {
-                    "br": [
-                        0.067316
-                    ],
-                    "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass20_2017",
-                    "xsec": 0.8594
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": false,
-            "issignal": true,
-            "keys": [
-		"haa_prod", 
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 1,
-            "lwidth": 3,
-            "resonance": 20,
-            "spimpose": true,
-            "tag": "Wh (20)"
-        },
-        {
-            "data": [
-                {
-                    "br": [
-                        0.2132
-                    ],
-                    "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass50_2017",
-                    "xsec": 1.37
-                },
-                {
-                    "br": [
-                        0.067316
-                    ],
-                    "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass50_2017",
-                    "xsec": 0.8594
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": true,
-            "issignal": true,
-            "keys": [
-		"haa_prod", 
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 1,
-            "lwidth": 3,
-            "lstyle": 2,
-            "resonance": 50,
-            "spimpose": false,
-            "tag": "Wh (50)"
-        },
-        {
-            "data": [
-                {
-                    "br": [
-                        0.2132
-                    ],
-                    "dset": [
                         "/NMSSM_WHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
@@ -1199,7 +1118,7 @@
             "lwidth": 3,
             "lstyle": 3,
             "resonance": 12,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (12)"
         },
         {
@@ -1242,6 +1161,46 @@
             "resonance": 15,
             "spimpose": false,
             "tag": "Wh (15)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.2132
+                    ],
+                    "dset": [
+                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass20_2017",
+                    "xsec": 1.37
+                },
+                {
+                    "br": [
+                        0.067316
+                    ],
+                    "dset": [
+                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass20_2017",
+                    "xsec": 0.8594
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "resonance": 20,
+            "spimpose": false,
+            "tag": "Wh (20)"
         },
         {   
             "data": [
@@ -1367,6 +1326,47 @@
             "tag": "Wh (40)"
         },
         {
+            "data": [
+                {
+                    "br": [
+                        0.2132
+                    ],
+                    "dset": [
+                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass50_2017",
+                    "xsec": 1.37
+                },
+                {
+                    "br": [
+                        0.067316
+                    ],
+                    "dset": [
+                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass50_2017",
+                    "xsec": 0.8594
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+	{
             "data": [
                 {
                     "br": [

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -989,87 +989,6 @@
                         0.2132
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass20_2017",
-                    "xsec": 1.37
-                },
-                {
-                    "br": [
-                        0.067316
-                    ],
-                    "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass20_2017",
-                    "xsec": 0.8594
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": false,
-            "issignal": true,
-            "keys": [
-		"haa_prod", 
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 1,
-            "lwidth": 3,
-            "resonance": 20,
-            "spimpose": true,
-            "tag": "Wh (20)"
-        },
-        {
-            "data": [
-                {
-                    "br": [
-                        0.2132
-                    ],
-                    "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass50_2017",
-                    "xsec": 1.37
-                },
-                {
-                    "br": [
-                        0.067316
-                    ],
-                    "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass50_2017",
-                    "xsec": 0.8594
-                }
-            ],
-            "fill": 0,
-            "isdata": false,
-            "isinvisible": true,
-            "issignal": true,
-            "keys": [
-		"haa_prod", 
-                "haa_signal",
-                "haa_mcbased"
-            ],
-            "lcolor": 1,
-            "lwidth": 3,
-            "lstyle": 2,
-            "resonance": 50,
-            "spimpose": false,
-            "tag": "Wh (50)"
-        },
-        {
-            "data": [
-                {
-                    "br": [
-                        0.2132
-                    ],
-                    "dset": [
                         "/NMSSM_WHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
@@ -1101,7 +1020,7 @@
             "lwidth": 3,
             "lstyle": 3,
             "resonance": 12,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (12)"
         },
         {
@@ -1144,6 +1063,46 @@
             "resonance": 15,
             "spimpose": false,
             "tag": "Wh (15)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.2132
+                    ],
+                    "dset": [
+                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass20_2017",
+                    "xsec": 1.37
+                },
+                {
+                    "br": [
+                        0.067316
+                    ],
+                    "dset": [
+                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass20_2017",
+                    "xsec": 0.8594
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "resonance": 20,
+            "spimpose": false,
+            "tag": "Wh (20)"
         },
         {   
             "data": [
@@ -1267,6 +1226,47 @@
             "resonance": 40,
             "spimpose": false,
             "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.2132
+                    ],
+                    "dset": [
+                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass50_2017",
+                    "xsec": 1.37
+                },
+                {
+                    "br": [
+                        0.067316
+                    ],
+                    "dset": [
+                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass50_2017",
+                    "xsec": 0.8594
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
         },
         {
             "data": [

--- a/test/haa4b/submit.sh
+++ b/test/haa4b/submit.sh
@@ -129,7 +129,7 @@ if [[ $step > 0.999 &&  $step < 2 ]]; then
        fi
 	# @btagSFMethod=1: Jet-by-jet updating of b-tagging status
 	# @btagSFMethod=2: Event reweighting using discriminator-dependent scale factors
-       runLocalAnalysisOverSamples.py -e runhaaAnalysis -b $BTAG_NTPL_OUTDIR -g $RUNLOG -j $NTPL_JSON -o $NTPL_OUTDIR -d $NTPL_INPUT -c $RUNNTPLANALYSISCFG -p "@runSystematics=False @runMVA=False @reweightTopPt=False @usemetNoHF=False @verbose=False @useDeepCSV=True @runQCD=False @runZH=True @btagSFMethod=2" -s $queue # -t MC13TeV_TTTo  -r True
+       runLocalAnalysisOverSamples.py -e runhaaAnalysis -b $BTAG_NTPL_OUTDIR -g $RUNLOG -j $NTPL_JSON -o $NTPL_OUTDIR -d $NTPL_INPUT -c $RUNNTPLANALYSISCFG -p "@runSystematics=False @runMVA=False @reweightTopPt=False @usemetNoHF=False @verbose=False @useDeepCSV=True @runQCD=False @runZH=True @btagSFMethod=1" -s $queue # -t MC13TeV_TTTo  -r True
    fi
 fi
 
@@ -207,7 +207,7 @@ if [[ $step > 2.999 && $step < 4 ]]; then
 
     if [[ $step == 3.02 ]]; then # make plots for data-driven QCD bkg
 	echo "MAKE SUMMARY ROOT FILE, for data-driven QCD estimate"
-	runPlotter --iEcm 13 --iLumi $INTLUMI --inDir ${NTPL_OUTDIR}/ --outFile ${PLOTTER}_qcd.root  --json $JSON --noPlot --fileOption RECREATE --key haa_mcbased --only "(all_optim_systs|all_optim_cut|(e|mu)_(A|B|C|D)_(SR|CR|CR5j)_(3b|4b)_(bdt)(|_shapes)(|_umetup|_umetdown|_jerup|_jerdown|_jesup|_jesdown|_scale_mup|_scale_mdown|_stat_eup|_stat_edown|_stat_eup|_stat_edown|_sys_eup|_sys_edown|_GS_eup|_GS_edown|_resRho_eup|_resRho_edown|_puup|_pudown|_pdfup|_pdfdown|_btagup|_btagdown))" $arguments
+	runPlotter --iEcm 13 --iLumi $INTLUMI --inDir ${NTPL_OUTDIR}/ --outFile ${PLOTTER}_qcd.root  --json $JSON --noPlot --fileOption RECREATE --key haa_mcbased --only "(all_optim_systs|all_optim_cut|(e|mu)_(A|B|C|D)_(SR|CR|CR5j)_(3b|4b)_(bdt|higgsMass|higgsPt|ht|pfmet|ptw|mtw|dphiWh|dRave|dmmin|dphijmet|lep_pt_raw)(|_shapes)(|_umetup|_umetdown|_jerup|_jerdown|_jesup|_jesdown|_scale_mup|_scale_mdown|_stat_eup|_stat_edown|_stat_eup|_stat_edown|_sys_eup|_sys_edown|_GS_eup|_GS_edown|_resRho_eup|_resRho_edown|_puup|_pudown|_pdfup|_pdfdown|_btagup|_btagdown))" $arguments
 	runPlotter --iEcm 13 --iLumi $INTLUMI --inDir ${NTPL_OUTDIR}/ --outDir $PLOTSDIR/mcbased_qcd/ --outFile ${PLOTTER}_qcd.root  --json $JSON --plotExt .pdf --key haa_mcbased --fileOption READ --noLog --only "(e|mu)_(A|B|C|D)_(SR|CR|CR5j)_(3b|4b)_bdt" $arguments
     fi
 


### PR DESCRIPTION
1. Reorder the signal datasets according to the increasing A mass points in json files;
2. Update HtCondor implementation in LaunchOnCondor.py;
3. A few other optimizations: adjust y-axis range of mtw and pfMet plots, bTagMethod is set to 1 by default and log scale of y-axis on prefit plots is configurable.