### PR TITLE
Updates on fitted normalizations and some bug fix and optimziations

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ runLocalAnalysisOverSamples.py -e my_exe -j data/my_samples.json -d my_input_dir
 
 # NTuple locations (29 Aug 2019 Updated)
 - 2016 DATA  and  MC Samples: ```/eos/cms/store/user/georgia/results_2019_07_10```
+
   2016 MC New Signal Samples: ```/eos/cms/store/user/yuanc/results_2019_08_09```
+
   2016 MC AMC NLO DY Samples: ```/eos/cms/store/user/yuanc/results_2019_08_23```
 - 2017 DATA  and  MC Samples: ```/eos/cms/store/user/zhangyi/results_2019_08_12```
 - 2018 DATA  and  MC Samples: ```/eos/cms/store/user/yuanc/results_2019_08_08```

--- a/README.md
+++ b/README.md
@@ -223,3 +223,9 @@ runLocalAnalysisOverSamples.py -e my_exe -j data/my_samples.json -d my_input_dir
  UserCode/bsmhiggs_fwk/test/haa4b/bin directory (also add it to the
  Buildfile there)
 
+# NTuple locations (29 Aug 2019 Updated)
+- 2016 DATA  and  MC Samples: ```/eos/cms/store/user/georgia/results_2019_07_10```
+  2016 MC New Signal Samples: ```/eos/cms/store/user/yuanc/results_2019_08_09```
+  2016 MC AMC NLO DY Samples: ```/eos/cms/store/user/yuanc/results_2019_08_23```
+- 2017 DATA  and  MC Samples: ```/eos/cms/store/user/zhangyi/results_2019_08_12```
+- 2018 DATA  and  MC Samples: ```/eos/cms/store/user/yuanc/results_2019_08_08```

--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -2356,7 +2356,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 	if(it->second.shortName.find("vhbb")!=string::npos){shapeInfo.uncScale["norm_vhbb"] = integral*0.10;}     
 
 	if(it->second.shortName.find("ttbarlig")!=string::npos){shapeInfo.uncScale["norm_toplight"] = integral*0.06;} 
-	//if(it->second.shortName.find("ttbarcba")!=string::npos){shapeInfo.uncScale["norm_topcc"] = integral*0.50;} 
+	//	if(it->second.shortName.find("ttbarcba")!=string::npos){shapeInfo.uncScale["norm_topcc"] = integral*0.50;} 
 	if(it->second.shortName.find("ttbargam")!=string::npos){shapeInfo.uncScale["norm_topgzw"] = integral*0.15;} 
 	if(it->second.shortName.find("singleto")!=string::npos){shapeInfo.uncScale["norm_singletop"] = integral*0.05;}
 	if (!subFake){
@@ -2517,18 +2517,20 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       //      if (simfit) {
       fprintf(pFile, "-------------------------------\n");  
       fprintf(pFile,"\n");
-      if(C->first.find("e" )!=string::npos) {
-	fprintf(pFile,"tt_norm_e rateParam bin1 ttbarbba 1\n");
-	fprintf(pFile,"tt_norm_e rateParam bin1 ttbarcba 1\n");  
-	//	fprintf(pFile,"ttc_norm_e rateParam bin1 ttbarcba 1\n"); 
-	if(runZh) {
-	  if (C->first.find("3b")!=string::npos) fprintf(pFile,"v_norm_3b_e rateParam bin1 zll 1 \n");    
-	  if (C->first.find("4b")!=string::npos) fprintf(pFile,"v_norm_4b_e rateParam bin1 zll 1 \n"); 
-	} else {
-	  if (C->first.find("3b")!=string::npos) fprintf(pFile,"v_norm_3b_e rateParam bin1 wlnu 1 \n");    
-	  if (C->first.find("4b")!=string::npos) fprintf(pFile,"v_norm_4b_e rateParam bin1 wlnu 1 \n"); 
-	}
-      } else if(C->first.find("mu")!=string::npos) {
+      //      if(C->first.find("e" )!=string::npos) {
+      fprintf(pFile,"tt_norm rateParam bin1 ttbarbba 1\n");
+      fprintf(pFile,"tt_norm rateParam bin1 ttbarcba 1\n");  
+      //	fprintf(pFile,"ttc_norm rateParam bin1 ttbarcba 1\n"); 
+      if(runZh) {
+	if (C->first.find("3b")!=string::npos) fprintf(pFile,"v_norm_3b rateParam bin1 zll 1 \n");    
+	if (C->first.find("4b")!=string::npos) fprintf(pFile,"v_norm_4b rateParam bin1 zll 1 \n"); 
+      } else {
+	if (C->first.find("3b")!=string::npos) fprintf(pFile,"v_norm_3b rateParam bin1 wlnu 1 \n");    
+	if (C->first.find("4b")!=string::npos) fprintf(pFile,"v_norm_4b rateParam bin1 wlnu 1 \n"); 
+      }
+      //} 
+      /*
+      if(C->first.find("mu")!=string::npos) {
 	fprintf(pFile,"tt_norm_mu rateParam bin1 ttbarbba 1\n");
 	fprintf(pFile,"tt_norm_mu rateParam bin1 ttbarcba 1\n");   
 	//	fprintf(pFile,"ttc_norm_mu rateParam bin1 ttbarcba 1\n");  
@@ -2540,7 +2542,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
           if (C->first.find("4b")!=string::npos) fprintf(pFile,"v_norm_4b_mu rateParam bin1 wlnu 1 \n"); 
         }                  
       }
-
+      */
       fprintf(pFile, "-------------------------------\n");  
       
       fclose(pFile);

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -2369,8 +2369,7 @@ int main(int argc, char* argv[])
 	      nCSVTtags += (btag_dsc>TightWP);
 	      
 	      // Fill b-jet vector:
-	      //if (hasCSVtagL) {  CSVLoosebJets.push_back(vJets[ijet]); }
-	      if (hasCSVtagM) {  CSVLoosebJets.push_back(vJets[ijet]); }
+	      if (hasCSVtagL) {  CSVLoosebJets.push_back(vJets[ijet]); }
 	    } // b-jet loop
 	    
 	  } // jet loop
@@ -2488,8 +2487,7 @@ int main(int argc, char* argv[])
 
 	  if (runZH){
 	    LorentzVector zll(selLeptons[0]+selLeptons[1]);    
-	    //passZmass=(fabs(zll.mass()-91)<15);        
-	    passZmass=(zll.mass()<100. && zll.mass()>85.);
+	    passZmass=(fabs(zll.mass()-91)<15);        
 
 	    wsum+=selLeptons[1];
 

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -1699,6 +1699,10 @@ int main(int argc, char* argv[])
         mon.fillHisto("eventflow",tag_cat,1,weight); 
 
 
+	if(is2017MC || is2017data){
+	    hasEMtrigger = hasEMtrigger || hasEMtrigger2;
+	    hasMMtrigger = hasMMtrigger || hasMMtrigger2;
+	}
         bool hasTrigger(false);
 	if(!isMC) {
 	  if(evcat!=fType) continue; 
@@ -2365,7 +2369,8 @@ int main(int argc, char* argv[])
 	      nCSVTtags += (btag_dsc>TightWP);
 	      
 	      // Fill b-jet vector:
-	      if (hasCSVtagL) {  CSVLoosebJets.push_back(vJets[ijet]); }
+	      //if (hasCSVtagL) {  CSVLoosebJets.push_back(vJets[ijet]); }
+	      if (hasCSVtagM) {  CSVLoosebJets.push_back(vJets[ijet]); }
 	    } // b-jet loop
 	    
 	  } // jet loop
@@ -2483,7 +2488,8 @@ int main(int argc, char* argv[])
 
 	  if (runZH){
 	    LorentzVector zll(selLeptons[0]+selLeptons[1]);    
-	    passZmass=(fabs(zll.mass()-91)<15);        
+	    //passZmass=(fabs(zll.mass()-91)<15);        
+	    passZmass=(zll.mass()<100. && zll.mass()>85.);
 
 	    wsum+=selLeptons[1];
 

--- a/test/haa4b/computeLimit/optimize_haa_Zh.py
+++ b/test/haa4b/computeLimit/optimize_haa_Zh.py
@@ -18,7 +18,7 @@ BIN             = []
 MODEL           = []
 
 LaunchOnCondor.Jobs_Queue='cmscaf1nd'
-FarmDirectory  = "FARM"
+FarmDirectory  = "FARM_Zh"
 JobName        = "computeLimits"
 CMSSW_BASE=os.environ.get('CMSSW_BASE')
 CWD=os.getcwd()
@@ -48,7 +48,7 @@ for model in MODELS:
          if(model=="SM"):
             suffix = "" 
             signalSuffixVec += [ suffix ]
-            OUTName         += ["SB13TeV_SM_Wh"]
+            OUTName         += ["SB13TeV_SM_Zh"]
             LandSArgOptions += [" --histo " + shape + "  --systpostfix _13TeV --shape "]
             BIN             += [bin]
             MODEL           += [model]
@@ -128,7 +128,7 @@ for signalSuffix in signalSuffixVec :
    DataCardsDir='cards_'+OUTName[iConf]+signalSuffix+binSuffix
 
    #prepare the output
-   OUT = CWD+'/JOBS/'+OUTName[iConf]+signalSuffix+binSuffix+'/'
+   OUT = CWD+'/JOBS_Zh/'+OUTName[iConf]+signalSuffix+binSuffix+'/'
    os.system('mkdir -p ' + OUT)
 
    #get the cuts
@@ -320,7 +320,7 @@ for signalSuffix in signalSuffixVec :
                Gcut.extend([ROOT.TGraph(len(SUBMASS))]) #also add a graph for shapeMax
 
                INbinSuffix = "_" + bin 
-               IN = CWD+'/JOBS/'+OUTName[iConf]+signalSuffix+INbinSuffix+'/'
+               IN = CWD+'/JOBS_Zh/'+OUTName[iConf]+signalSuffix+INbinSuffix+'/'
                try:
                   listcuts = open(IN+'cuts.txt',"r")
                   mi=0
@@ -369,16 +369,17 @@ for signalSuffix in signalSuffixVec :
            SCRIPT.writelines('cd -;\n')
 
            cardsdir=DataCardsDir+"/"+('%04.0f' % float(m));
-           SCRIPT.writelines('mkdir -p out;\ncd out;\n') #--blind instead of --simfit
+           SCRIPT.writelines('mkdir -p out_{};\ncd out_{};\n'.format(m,m)) #--blind instead of --simfit
 #           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --blind --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
-           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --subFake --modeDD " + " " + LandSArg + cutStr  +" ;\n")
+           #SCRIPT.writelines("computeLimit --runZh  --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --subFake --modeDD " + " " + LandSArg + cutStr  +" ;\n")
+           SCRIPT.writelines("computeLimit --runZh  --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
            SCRIPT.writelines("sh combineCards.sh;\n"); 
 #           SCRIPT.writelines("text2workspace.py card_combined.dat -o workspace.root --PO verbose --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n") 
            SCRIPT.writelines("text2workspace.py card_combined.dat -o workspace.root --PO verbose --channel-masks  --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n")  
            #compute pvalue
            SCRIPT.writelines("combine -M ProfileLikelihood --signif --pvalue -m " +  str(m) + " workspace.root > COMB.log;\n")
 #           SCRIPT.writelines("combine -M FitDiagnostics workspace.root -v 3 --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL --rMin=-20 --rMax=20 --robustFit 1 > log.txt \n")
-           SCRIPT.writelines("combine -M FitDiagnostics workspace.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_e_A_SR_3b=1,mask_mu_A_SR_3b=1,mask_e_A_SR_4b=1,mask_mu_A_SR_4b=1 > log.txt \n") 
+           SCRIPT.writelines("combine -M FitDiagnostics workspace.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ee_A_SR_3b=1,mask_mumu_A_SR_3b=1,mask_ee_A_SR_4b=1,mask_mumu_A_SR_4b=1 > log.txt \n") 
            # save likelihood fit info
            SCRIPT.writelines("python " + CMSSW_BASE + "/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/print.py -u fitDiagnostics.root > simfit_m"+ str(m)+".txt \n")
 	   SCRIPT.writelines("python " + CMSSW_BASE + "/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -A -a fitDiagnostics.root -g Nuisance_CrossCheck.root >> simfit_m"+ str(m) +".txt\n")

--- a/test/haa4b/computeLimit/plotLimit.C
+++ b/test/haa4b/computeLimit/plotLimit.C
@@ -88,7 +88,7 @@ void printLimits(FILE* pFile, TGraph* graph, double Mmin=12, double Mmax=60){
 
 
 
-void plotLimit(string outputDir="./", TString inputs="", TString inputXSec="", bool strengthLimit=true, bool blind=false, double energy=7, double luminosity=5.035, TString legendName="Wh channels")
+void plotLimit(string outputDir="./", TString inputs="", TString inputXSec="", bool strengthLimit=true, bool blind=false, double energy=7, double luminosity=5.035, TString legendName="Wh channels", bool logY=true)
 {
    setTDRStyle();  
    gStyle->SetPadTopMargin   (0.05);
@@ -206,13 +206,28 @@ void plotLimit(string outputDir="./", TString inputs="", TString inputXSec="", b
   framework->GetYaxis()->SetTitleOffset(1.70);
   if(strengthLimit){
     framework->GetYaxis()->SetTitle("#mu = #sigma_{95%} / #sigma_{th}");
-    framework->GetYaxis()->SetRangeUser(1E-2,1E3);
-    c->SetLogy(true);
+    if(logY){
+      framework->GetYaxis()->SetRangeUser(1E-1,1E3);
+      c->SetLogy(true);
+      outputDir += "log/";
+    }else{
+      framework->GetYaxis()->SetRangeUser(1E-2,5);
+      c->SetLogy(false);
+      outputDir += "linear/";
+    }
   }else{
     framework->GetYaxis()->SetTitle((string("#sigma_{95%} (") + prod +") x BR (pb)").c_str());
-    framework->GetYaxis()->SetRangeUser(1E-2,1E3);
-    c->SetLogy(true);
+    if(logY){
+      framework->GetYaxis()->SetRangeUser(1E-1,1E3);
+      c->SetLogy(true);
+      outputDir += "log/";
+    }else{
+      framework->GetYaxis()->SetRangeUser(1E-2,5);
+      c->SetLogy(false);
+      outputDir += "linear/";
+    }
   }
+  system(string("mkdir -p " + outputDir).c_str());
   framework->GetXaxis()->SetLabelOffset(0.007);
   framework->GetXaxis()->SetLabelSize(0.03);
   framework->GetXaxis()->SetTitleOffset(1.0);

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -669,7 +669,7 @@
 		    ],
 		    "gtag": "94X_mc2017_realistic_v14",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_2017_amcNLO",
-		    "xsec": 18610 
+		    "xsec": 5765.4 
 		},
 		{
 		    "br": [ 0.87 ],
@@ -678,7 +678,7 @@
 		    ],
 		    "gtag": "94X_mc2017_realistic_v14",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_2017_ext1_amcNLO",
-		    "xsec": 18610 
+		    "xsec": 5765.4
 		}
             ],
             "isdata": false,
@@ -793,6 +793,62 @@
         {
             "color": 622,
             "data": [
+	        {
+		    "br": [ 1.0 ],
+		    "dset": [
+			"/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_W0Jets_2017_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 0.35 ],
+		    "dset": [
+		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_W1Jets_2017_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 0.65 ],
+		    "dset": [
+		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_W1Jets_2017_ext1_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 0.49 ],
+		    "dset": [
+		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_W2Jets_2017_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 0.51 ],
+		    "dset": [
+		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_W2Jets_2017_ext1_amcNLO",
+		    "xsec":
+		}
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 622,
+            "data": [
                 {
                     "br": [
                         0.6
@@ -862,8 +918,7 @@
             ],
             "isdata": false,
             "keys": [
-		"haa_prod", 
-                "haa_mcbased"
+		"haa_prod"
             ],
             "tag": "W#rightarrow l#nu"
         },

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -793,62 +793,6 @@
         {
             "color": 622,
             "data": [
-	        {
-		    "br": [ 1.0 ],
-		    "dset": [
-			"/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
-		    ],
-		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_W0Jets_2017_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 0.35 ],
-		    "dset": [
-		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-		    ],
-		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_W1Jets_2017_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 0.65 ],
-		    "dset": [
-		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
-		    ],
-		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_W1Jets_2017_ext1_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 0.49 ],
-		    "dset": [
-		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-		    ],
-		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_W2Jets_2017_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 0.51 ],
-		    "dset": [
-		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
-		    ],
-		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_W2Jets_2017_ext1_amcNLO",
-		    "xsec":
-		}
-            ],
-            "isdata": false,
-            "keys": [
-		"haa_prod", 
-                "haa_mcbased"
-            ],
-            "tag": "W#rightarrow l#nu"
-        },
-        {
-            "color": 622,
-            "data": [
                 {
                     "br": [
                         0.6
@@ -918,7 +862,8 @@
             ],
             "isdata": false,
             "keys": [
-		"haa_prod"
+		"haa_prod",
+		"haa_mcbased"
             ],
             "tag": "W#rightarrow l#nu"
         },

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -640,44 +640,6 @@
         {
             "color": 622,
             "data": [
-	        {
-		    "br": [ 1.0 ],
-		    "dset": [
-			"/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
-		    ],
-		    "gtag": "102X_upgrade2018_realistic_v18",
-		    "dtag": "MC13TeV_W0Jets_2018_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 1.0 ],
-		    "dset": [
-		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
-		    ],
-		    "gtag": "102X_upgrade2018_realistic_v18",
-		    "dtag": "MC13TeV_W1Jets_2018_amcNLO",
-		    "xsec":
-		},
-	        {
-		    "br": [ 1.0 ],
-		    "dset": [
-		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
-		    ],
-		    "gtag": "102X_upgrade2018_realistic_v18",
-		    "dtag": "MC13TeV_W2Jets_2018_amcNLO",
-		    "xsec":
-		}
-            ],
-            "isdata": false,
-            "keys": [
-		"haa_prod", 
-                "haa_mcbased"
-            ],
-            "tag": "W#rightarrow l#nu"
-        },
-        {
-            "color": 622,
-            "data": [
                 {
                     "br": [
                         1.0
@@ -736,7 +698,8 @@
             ],
             "isdata": false,
             "keys": [
-		"haa_prod"
+		"haa_prod",
+		"haa_mcbased"
             ],
             "tag": "W#rightarrow l#nu"
         },

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -552,7 +552,7 @@
 		    ],
 		    "gtag": "102X_upgrade2018_realistic_v18",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_2018_amcNLO",
-		    "xsec": 18610
+		    "xsec": 5765.4
 		},
 		{
 		    "br": [ 0.995 ],
@@ -561,7 +561,7 @@
 		    ],
 		    "gtag": "102X_upgrade2018_realistic_v18",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_2018_ext2_amcNLO",
-		    "xsec": 18610
+		    "xsec": 5765.4
 		},
             ],
             "isdata": false,
@@ -640,6 +640,44 @@
         {
             "color": 622,
             "data": [
+	        {
+		    "br": [ 1.0 ],
+		    "dset": [
+			"/WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+		    ],
+		    "gtag": "102X_upgrade2018_realistic_v18",
+		    "dtag": "MC13TeV_W0Jets_2018_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 1.0 ],
+		    "dset": [
+		        "/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+		    ],
+		    "gtag": "102X_upgrade2018_realistic_v18",
+		    "dtag": "MC13TeV_W1Jets_2018_amcNLO",
+		    "xsec":
+		},
+	        {
+		    "br": [ 1.0 ],
+		    "dset": [
+		        "/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+		    ],
+		    "gtag": "102X_upgrade2018_realistic_v18",
+		    "dtag": "MC13TeV_W2Jets_2018_amcNLO",
+		    "xsec":
+		}
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 622,
+            "data": [
                 {
                     "br": [
                         1.0
@@ -698,8 +736,7 @@
             ],
             "isdata": false,
             "keys": [
-		"haa_prod", 
-                "haa_mcbased"
+		"haa_prod"
             ],
             "tag": "W#rightarrow l#nu"
         },


### PR DESCRIPTION
1. Switch back to the merged normalizations;
2. Fix cross section bugs of NLO DY samples in 2017 and 2018;
3. Add 'ZH' channel version of optimize_haa.py: optimize_haa_Zh.py;
4. Add linear scale of y-axis in plotLimit.C and make it configurable;
5. Add analysis ntuple locations in README.