### PR TITLE
Fix naming bug of some datasets

### DIFF
--- a/interface/statWgt.h
+++ b/interface/statWgt.h
@@ -54,7 +54,7 @@ const std::map<std::string, std::pair <int, float> > mStat =
     */
     //WJets 2017
     { "MC13TeV_WJets_2017"     , std::make_pair(77700506, 50690) },
-    { "MC13TeV_WJets_2017_ext1", std::make_pair(77700506, 50690) },
+    { "MC13TeV_WJets_ext1_2017", std::make_pair(77700506, 50690) },
     { "MC13TeV_W1Jets_2017"    , std::make_pair(54147812, 9493) },
     { "MC13TeV_W2Jets_2017"    , std::make_pair(6577492, 3120) },
     { "MC13TeV_W3Jets_2017"    , std::make_pair(19700377, 942.3) },
@@ -88,13 +88,13 @@ const std::map<std::string, std::pair <int, float> > mStat =
     { "MC13TeV_DYJetsToLL_10to50_2017" , std::make_pair(39521230, 18610) },
     
     { "MC13TeV_DYJetsToLL_M50_2017" , std::make_pair(97800939, 4895) },
-    { "MC13TeV_DYJetsToLL_M50_2017_ext1" , std::make_pair(97800939, 4895) },
+    { "MC13TeV_DYJetsToLL_M50_ext1_2017" , std::make_pair(97800939, 4895) },
     { "MC13TeV_DY1JetsToLL_M50_2017" , std::make_pair(77190729, 1016) },
-    { "MC13TeV_DY1JetsToLL_M50_2017_ext1" , std::make_pair(77190729, 1016) },
+    { "MC13TeV_DY1JetsToLL_M50_ext1_2017" , std::make_pair(77190729, 1016) },
     { "MC13TeV_DY2JetsToLL_M50_2017" , std::make_pair(9790490, 331.4) },
-    { "MC13TeV_DY2JetsToLL_M50_2017_ext1" , std::make_pair(9790490, 311.4) },
+    { "MC13TeV_DY2JetsToLL_M50_ext1_2017" , std::make_pair(9790490, 311.4) },
     { "MC13TeV_DY3JetsToLL_M50_2017" , std::make_pair(6897933, 96.36) },
-    { "MC13TeV_DY3JetsToLL_M50_2017_ext1" , std::make_pair(6897933, 96.36) },
+    { "MC13TeV_DY3JetsToLL_M50_ext1_2017" , std::make_pair(6897933, 96.36) },
     { "MC13TeV_DY4JetsToLL_M50_2017" , std::make_pair(4328648, 51.4) },
     //DY 2018
     { "MC13TeV_DYJetsToLL_10to50_2018" , std::make_pair(39392062, 18610) },
@@ -204,7 +204,7 @@ namespace xsecWeightCalculator
                 this_kf = 1.18;
                 this_events[0] = (mStat.find("MC13TeV_DYJetsToLL_M50_2017")->second).first; this_xsec[0] = (mStat.find("MC13TeV_DYJetsToLL_M50_2017")->second).second;
                 this_events[1] = (mStat.find("MC13TeV_DY1JetsToLL_M50_2017")->second).first; this_xsec[1] = (mStat.find("MC13TeV_DY1JetsToLL_M50_2017")->second).second;
-                this_events[2] = (mStat.find("MC13TeV_DY2JetsToLL_M50_2017_ext1")->second).first; this_xsec[2] = (mStat.find("MC13TeV_DY2JetsToLL_M50_2017_ext1")->second).second;
+                this_events[2] = (mStat.find("MC13TeV_DY2JetsToLL_M50_ext1_2017")->second).first; this_xsec[2] = (mStat.find("MC13TeV_DY2JetsToLL_M50_ext1_2017")->second).second;
                 this_events[3] = (mStat.find("MC13TeV_DY3JetsToLL_M50_2017")->second).first; this_xsec[3] = (mStat.find("MC13TeV_DY3JetsToLL_M50_2017")->second).second;
                 this_events[4] = (mStat.find("MC13TeV_DY4JetsToLL_M50_2017")->second).first; this_xsec[4] = (mStat.find("MC13TeV_DY4JetsToLL_M50_2017")->second).second;
             } 

--- a/test/haa4b/getTotNumEvtsWDY.py
+++ b/test/haa4b/getTotNumEvtsWDY.py
@@ -9,12 +9,12 @@ GREEN    = '\033[92m'
 FAIL     = '\033[91m'
 END      = '\033[0m'
 
-inputdir = "results_2019_06_04"
+inputdir = "results_2019_08_12"
 #inputdir = "results_2019_06_04"
 #dtag = sys.argv[1]
 #dtags = ["MC13TeV_WJets_2017","MC13TeV_WJets_2017_ext1","MC13TeV_W1Jets_2017","MC13TeV_W2Jets_2017","MC13TeV_W3Jets_2017","MC13TeV_W4Jets_2017"]
-#dtags = ["MC13TeV_DYJetsToLL_10to50_2017","MC13TeV_DYJetsToLL_M50_2017","MC13TeV_DYJetsToLL_M50_2017_ext1","MC13TeV_DY1JetsToLL_M50_2017","MC13TeV_DY1JetsToLL_M50_2017_ext1","MC13TeV_DY2JetsToLL_M50_2017_ext1","MC13TeV_DY2JetsToLL_M50_2017","MC13TeV_DY3JetsToLL_M50_2017","MC13TeV_DY3JetsToLL_M50_2017_ext1","MC13TeV_DY4JetsToLL_M50_2017","MC13TeV_WJets_2017","MC13TeV_WJets_2017_ext1","MC13TeV_W1Jets_2017","MC13TeV_W2Jets_2017","MC13TeV_W3Jets_2017","MC13TeV_W4Jets_2017"]
-dtags = ["MC13TeV_DYJetsToLL_10to50_2016","MC13TeV_DY1JetsToLL_10to50_2016","MC13TeV_DY2JetsToLL_10to50_2016","MC13TeV_DY3JetsToLL_10to50_2016","MC13TeV_DY4JetsToLL_10to50_2016","MC13TeV_DYJetsToLL_50toInf_ext1_2016","MC13TeV_DYJetsToLL_50toInf_ext2_2016","MC13TeV_DY1JetsToLL_50toInf_2016","MC13TeV_DY2JetsToLL_50toInf_2016","MC13TeV_DY3JetsToLL_50toInf_2016","MC13TeV_DY4JetsToLL_50toInf_2016","MC13TeV_WJets_2016","MC13TeV_WJets_ext2_2016","MC13TeV_W1Jets_2016","MC13TeV_W2Jets_2016","MC13TeV_W2Jets_ext1_2016","MC13TeV_W3Jets_2016","MC13TeV_W3Jets_ext1_2016","MC13TeV_W4Jets_2016","MC13TeV_W4Jets_ext1_2016","MC13TeV_W4Jets_ext2_2016"]
+dtags = ["MC13TeV_DYJetsToLL_10to50_2017","MC13TeV_DYJetsToLL_M50_2017","MC13TeV_DYJetsToLL_M50_ext1_2017","MC13TeV_DY1JetsToLL_M50_2017","MC13TeV_DY1JetsToLL_M50_ext1_2017","MC13TeV_DY2JetsToLL_M50_ext1_2017","MC13TeV_DY2JetsToLL_M50_2017","MC13TeV_DY3JetsToLL_M50_2017","MC13TeV_DY3JetsToLL_M50_ext1_2017","MC13TeV_DY4JetsToLL_M50_2017","MC13TeV_WJets_2017","MC13TeV_WJets_ext1_2017","MC13TeV_W1Jets_2017","MC13TeV_W2Jets_2017","MC13TeV_W3Jets_2017","MC13TeV_W4Jets_2017"]
+#dtags = ["MC13TeV_DYJetsToLL_10to50_2016","MC13TeV_DY1JetsToLL_10to50_2016","MC13TeV_DY2JetsToLL_10to50_2016","MC13TeV_DY3JetsToLL_10to50_2016","MC13TeV_DY4JetsToLL_10to50_2016","MC13TeV_DYJetsToLL_50toInf_ext1_2016","MC13TeV_DYJetsToLL_50toInf_ext2_2016","MC13TeV_DY1JetsToLL_50toInf_2016","MC13TeV_DY2JetsToLL_50toInf_2016","MC13TeV_DY3JetsToLL_50toInf_2016","MC13TeV_DY4JetsToLL_50toInf_2016","MC13TeV_WJets_2016","MC13TeV_WJets_ext2_2016","MC13TeV_W1Jets_2016","MC13TeV_W2Jets_2016","MC13TeV_W2Jets_ext1_2016","MC13TeV_W3Jets_2016","MC13TeV_W3Jets_ext1_2016","MC13TeV_W4Jets_2016","MC13TeV_W4Jets_ext1_2016","MC13TeV_W4Jets_ext2_2016"]
 #dtags = ["MC13TeV_DYJetsToLL_10to50_2017"]
 
 printFiles = True
@@ -25,8 +25,8 @@ num=1
 for tag in dtags:
   print(str(num)+". Processing the tag: "+tag)
   #ntplpath = "/eos/cms/store/user/yuanc/"+inputdir+'/*/crab_'+tag+'*/*/*/'
-  ntplpath = "/eos/cms/store/user/georgia/results_2019_07_10/*/crab_"+tag+'*/*/*/'
-  #ntplpath = "/eos/cms/store/user/zhangyi/results_2018_07_10/*/crab_"+tag+'*/*/*/'
+  #ntplpath = "/eos/cms/store/user/georgia/results_2019_07_10/*/crab_"+tag+'*/*/*/'
+  ntplpath = "/eos/cms/store/user/zhangyi/results_2019_08_12/*/crab_"+tag+'*/*/*/'
   nFiles = 0
   nTot = 0
   nPos = 0

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -856,7 +856,7 @@
 			"/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
 		    ],
 		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_DYJetsToLL_10to50_2016_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_10to50_amcNLO_2016",
 		    "xsec": 18610
 		},
 		{
@@ -865,7 +865,7 @@
 			"/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
 		    ],
 		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-		    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_50toInf_amcNLO_ext2_2016",
 		    "xsec": 5765.4
 		}
 	    ],

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -668,7 +668,7 @@
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
 		    ],
 		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_DYJetsToLL_M50_2017_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_2017",
 		    "xsec": 5765.4 
 		},
 		{

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -612,7 +612,7 @@
                         "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_TTGJets_2017_ext1",
+                    "dtag": "MC13TeV_TTGJets_ext1_2017",
                     "xsec": 3.697
                 },
                 {
@@ -677,7 +677,7 @@
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
 		    ],
 		    "gtag": "94X_mc2017_realistic_v14",
-		    "dtag": "MC13TeV_DYJetsToLL_M50_2017_ext1_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_ext1_2017",
 		    "xsec": 5765.4
 		}
             ],
@@ -715,7 +715,7 @@
                         "/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_DY1JetsToLL_M50_2017_ext1",
+                    "dtag": "MC13TeV_DY1JetsToLL_M50_ext1_2017",
                     "xsec": 1016
                 },
                 {
@@ -733,7 +733,7 @@
                         "/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_DY2JetsToLL_M50_2017_ext1",
+                    "dtag": "MC13TeV_DY2JetsToLL_M50_ext1_2017",
                     "xsec": 331.4
                 },
                 {
@@ -751,7 +751,7 @@
                         "/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_DY3JetsToLL_M50_2017_ext1",
+                    "dtag": "MC13TeV_DY3JetsToLL_M50_ext1_2017",
                     "xsec": 96.36
                 },
                 {
@@ -778,7 +778,7 @@
                         "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_DYJetsToLL_M50_2017_ext1",
+                    "dtag": "MC13TeV_DYJetsToLL_M50_ext1_2017",
                     "xsec": 4895
                 }
             ],
@@ -801,7 +801,7 @@
                         "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_WJets_2017_ext1",
+                    "dtag": "MC13TeV_WJets_ext1_2017",
                     "xsec": 50690
                 },
                 {

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -551,7 +551,7 @@
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
 		    ],
 		    "gtag": "102X_upgrade2018_realistic_v18",
-		    "dtag": "MC13TeV_DYJetsToLL_M50_2018_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_2018",
 		    "xsec": 5765.4
 		},
 		{
@@ -560,7 +560,7 @@
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext2-v1/MINIAODSIM"
 		    ],
 		    "gtag": "102X_upgrade2018_realistic_v18",
-		    "dtag": "MC13TeV_DYJetsToLL_M50_2018_ext2_amcNLO",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_ext2_2018",
 		    "xsec": 5765.4
 		},
             ],


### PR DESCRIPTION
Fix the naming bug of the datasets with 'amcNLO' and 'ext' postfix to avoid double-counting when merging root files in step >=3.0 in the submit.sh