### PR TITLE
Update 2017 and 2018 signal samples

### DIFF
--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -1113,25 +1113,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-12_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass12_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+			""
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass12_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1154,25 +1154,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-15_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-15_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass15_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-15_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-15_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass15_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1195,25 +1195,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-20_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass20_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-20_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass20_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1235,25 +1235,25 @@
             "data": [
                 {   
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-25_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-25_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass25_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-25_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-25_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass25_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1276,25 +1276,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-30_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-30_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass30_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-30_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-30_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass30_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1317,25 +1317,25 @@
             "data": [
                 {   
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-40_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-40_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass40_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-40_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-40_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass40_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1358,25 +1358,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-50_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass50_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-50_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass50_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1399,25 +1399,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-60_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-60_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass60_2017",
-                    "xsec": 1.37
+                    "xsec": "1.37*0.65"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-60_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-60_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass60_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -908,50 +908,6 @@
                         1.0
                     ],
                     "dset": [
-                        "/QCD_Pt-15to20_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt15to20_MuEnrPt5_2017",
-                    "xsec": 3819570
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                        "/QCD_Pt-20to30_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt20to30_MuEnrPt5_2017",
-                    "xsec": 2960198.4
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                        "/QCD_Pt-30to50_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt30to50_MuEnrPt5_2017",
-                    "xsec": 1652471.46
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                        "/QCD_Pt-50to80_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt50to80_MuEnrPt5_2017",
-                    "xsec": 437504.1
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
                         "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
@@ -1001,28 +957,6 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2017",
                     "xsec": 79.02553776
-                },
-                {
-                    "br": [
-                        0.00059
-                    ],
-                    "dset": [
-                        "/QCD_Pt_20to30_bcToE_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt_20to30_bcToE_2017",
-                    "xsec": 557627000 
-                },
-                {
-                    "br": [
-                        0.00255
-                    ],
-                    "dset": [
-                        "/QCD_Pt_30to80_bcToE_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
-                    ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_QCD_Pt_30to80_bcToE_2017",
-                    "xsec": 159068000
                 },
                 {
                     "br": [
@@ -1228,7 +1162,7 @@
             "lcolor": 1,
             "lwidth": 3,
             "resonance": 20,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (20)"
         },
         {   

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -1058,7 +1058,7 @@
                 },
                 {
                     "br": [
-			""
+			0.10099
                     ],
                     "dset": [
 			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -10,7 +10,7 @@
                     "dset": [
                         "/MuonEG/Run2018A-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_MuEG2018A_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -22,7 +22,7 @@
                     "dset": [
                         "/MuonEG/Run2018B-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_MuEG2018B_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -34,7 +34,7 @@
                     "dset": [
                         "/MuonEG/Run2018C-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_MuEG2018C_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -46,7 +46,7 @@
                     "dset": [
                         "/MuonEG/Run2018D-PromptReco-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Prompt_v13",
+                    "gtag": "102X_dataRun2_Prompt_v14",
                     "dtag": "Data13TeV_MuEG2018D_PromptReco_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -58,7 +58,7 @@
                     "dset": [
                         "/EGamma/Run2018A-17Sep2018-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_EGamma2018A_17Sep2018_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -70,7 +70,7 @@
                     "dset": [
                         "/EGamma/Run2018B-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_EGamma2018B_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -82,7 +82,7 @@
                     "dset": [
                         "/EGamma/Run2018C-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_EGamma2018C_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -94,7 +94,7 @@
                     "dset": [
                         "/EGamma/Run2018D-PromptReco-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Prompt_v13",
+                    "gtag": "102X_dataRun2_Prompt_v14",
                     "dtag": "Data13TeV_EGamma2018D_PromptReco_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -106,7 +106,7 @@
                     "dset": [
                         "/SingleMuon/Run2018A-17Sep2018-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_SingleMuon2018A_17Sep2018_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -118,7 +118,7 @@
                     "dset": [
                         "/SingleMuon/Run2018B-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_SingleMuon2018B_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -130,7 +130,7 @@
                     "dset": [
                         "/SingleMuon/Run2018C-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_SingleMuon2018C_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -142,7 +142,7 @@
                     "dset": [
                         "/SingleMuon/Run2018D-PromptReco-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Prompt_v13",
+                    "gtag": "102X_dataRun2_Prompt_v14",
                     "dtag": "Data13TeV_SingleMuon2018D_PromptReco_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -154,7 +154,7 @@
                     "dset": [
                         "/DoubleMuon/Run2018A-17Sep2018-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_DoubleMuon2018A_17Sep2018_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -166,7 +166,7 @@
                     "dset": [
                         "/DoubleMuon/Run2018B-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_DoubleMuon2018B_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -178,7 +178,7 @@
                     "dset": [
                         "/DoubleMuon/Run2018C-17Sep2018-v1/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Sep2018ABC_v2",
+                    "gtag": "102X_dataRun2_v11",
                     "dtag": "Data13TeV_DoubleMuon2018C_17Sep2018_v1",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -190,7 +190,7 @@
                     "dset": [
                         "/DoubleMuon/Run2018D-PromptReco-v2/MINIAOD"
                     ],
-                    "gtag": "102X_dataRun2_Prompt_v13",
+                    "gtag": "102X_dataRun2_Prompt_v14",
                     "dtag": "Data13TeV_DoubleMuon2018D_PromptReco_v2",
                     "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
                     "xsec": 1.0
@@ -217,7 +217,7 @@
                     "dset": [
                        "/WW_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WW_2018",
                     "xsec": 118.7
                 },
@@ -228,7 +228,7 @@
                     "dset": [
                       "/WZ_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WZ_2018",
                     "xsec": 47.13
                 },
@@ -239,7 +239,7 @@
                     "dset": [
                       "/ZZ_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_ZZ_2018",
                     "xsec": 16.523
                 },
@@ -250,7 +250,7 @@
                     "dset": [
                       "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_ZZZ_2018",
                     "xsec": 0.01398
                 },
@@ -261,7 +261,7 @@
                     "dset": [
                       "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WZZ_2018",
                     "xsec": 0.05565
                 },
@@ -272,7 +272,7 @@
                     "dset": [
                       "/WWZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WWZ_2018",
                     "xsec": 0.1651
                 },
@@ -283,7 +283,7 @@
                     "dset": [
                       "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WWW_4F_2018",
                     "xsec": 0.2086
                 }
@@ -306,7 +306,7 @@
                     "dset": [
                       "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v3/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_SingleT_s_2018",
                     "xsec": 3.354
                 },
@@ -317,7 +317,7 @@
                     "dset": [
                       "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_SingleT_t_antitop_2018",
                     "xsec": 26.30875
                 },
@@ -328,7 +328,7 @@
                     "dset": [
                       "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_SingleT_t_top_2018",
                     "xsec": 44.2065
                 },
@@ -339,7 +339,7 @@
                     "dset": [
                       "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_SingleT_tW_antitop_2018",
                     "xsec": 35.6
                 },
@@ -350,7 +350,7 @@
                     "dset": [
                       "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_SingleT_tW_top_2018",
                     "xsec": 35.6
                 }
@@ -372,7 +372,7 @@
                     "dset": [ 
                       "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
                     "xsec": 88.29
                 },
@@ -383,7 +383,7 @@
                     "dset": [
                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
                     "xsec": 365.34
                 },
@@ -394,7 +394,7 @@
                     "dset": [
                       "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToHadronic_powheg_2018",
                     "xsec": 377.96
                 }
@@ -416,7 +416,7 @@
                     "dset": [ 
                       "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
                     "xsec": 88.29
                 },
@@ -427,7 +427,7 @@
                     "dset": [
                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
                     "xsec": 365.34
                 },
@@ -438,7 +438,7 @@
                     "dset": [
                       "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToHadronic_powheg_2018",
                     "xsec": 377.96
                 }
@@ -460,7 +460,7 @@
                     "dset": [ 
                       "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
                     "xsec": 88.29
                 },
@@ -471,7 +471,7 @@
                     "dset": [
                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
                     "xsec": 365.34
                 },
@@ -482,7 +482,7 @@
                     "dset": [
                       "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                      ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTToHadronic_powheg_2018",
                     "xsec": 377.96
                 }
@@ -503,7 +503,7 @@
                     "dset": [
                       "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTGJets_2018",
                     "xsec": 3.697
                 },
@@ -512,7 +512,7 @@
                     "dset": [
                       "/TGJets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TGJets_2018",
                     "xsec": 2.967
                 },
@@ -521,7 +521,7 @@
                     "dset": [
                       "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTWJetslnu_2018",
                     "xsec": 0.2043
                 },
@@ -530,7 +530,7 @@
                     "dset": [
                       "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_TTZJets2l2nu_2018",
                     "xsec": 0.2529
                 }
@@ -550,7 +550,7 @@
 		    "dset": [
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
 		    ],
-		    "gtag": "102X_upgrade2018_realistic_v18",
+		    "gtag": "102X_upgrade2018_realistic_v19",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_2018",
 		    "xsec": 5765.4
 		},
@@ -559,10 +559,10 @@
 		    "dset": [
 		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext2-v1/MINIAODSIM"
 		    ],
-		    "gtag": "102X_upgrade2018_realistic_v18",
+		    "gtag": "102X_upgrade2018_realistic_v19",
 		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_ext2_2018",
 		    "xsec": 5765.4
-		},
+		}
             ],
             "isdata": false,
             "keys": [
@@ -579,7 +579,7 @@
                     "dset": [
                       "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2018",
                     "xsec": 18610
                 },
@@ -588,7 +588,7 @@
                     "dset": [
                       "/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],                                                                                                                                                                                      
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DY1JetsToLL_M50_2018",
                     "xsec": 725
                 },
@@ -597,7 +597,7 @@
                     "dset": [
                       "/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DY2JetsToLL_M50_2018",
                     "xsec": 394.5
                 },
@@ -606,7 +606,7 @@
                     "dset": [
                       "/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DY3JetsToLL_M50_2018",
                     "xsec": 96.47
                 },
@@ -615,7 +615,7 @@
                     "dset": [
                       "/DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DY4JetsToLL_M50_2018",
                     "xsec": 40.44
                 },
@@ -624,7 +624,7 @@
                     "dset": [
                       "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_2018",
                     "xsec": 6100.8
                 }
@@ -647,7 +647,7 @@
                     "dset": [
                       "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_2018",
                     "xsec": 50960
                 },
@@ -658,7 +658,7 @@
                     "dset": [
                       "/W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_W1Jets_2018",
                     "xsec": 9493
                 },
@@ -669,7 +669,7 @@
                     "dset": [
                       "/W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_W2Jets_2018",
                     "xsec": 3120
                 },
@@ -680,7 +680,7 @@
                     "dset": [
                       "/W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_W3Jets_2018",
                     "xsec": 942.3
                 },
@@ -691,7 +691,7 @@
                     "dset": [
                       "/W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_W4Jets_2018",
                     "xsec": 524.2
                 }
@@ -713,7 +713,7 @@
                     "dset": [
                       "/QCD_Pt-80to120_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2018",
                     "xsec": 350000
                 },
@@ -724,7 +724,7 @@
                     "dset": [
                       "/QCD_Pt-120to170_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2018",
                     "xsec": 62964
                 },
@@ -735,7 +735,7 @@
                     "dset": [
                       "/QCD_Pt-170to300_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2018",
                     "xsec": 18810
                 },
@@ -746,53 +746,9 @@
                     "dset": [
                       "/QCD_Pt-300toInf_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2018",
                     "xsec": 1350
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                      "/QCD_Pt-15to20_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
-                    ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
-                    "dtag": "MC13TeV_QCD_Pt15to20_MuEnrPt5_2018",
-                    "xsec": 3819570
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                      "/QCD_Pt-20to30_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v4/MINIAODSIM"
-                    ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
-                    "dtag": "MC13TeV_QCD_Pt20to30_MuEnrPt5_2018",
-                    "xsec": 2960198.4
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                      "/QCD_Pt-30to50_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
-                    ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
-                    "dtag": "MC13TeV_QCD_Pt30to50_MuEnrPt5_2018",
-                    "xsec": 1652471.46
-                },
-                {
-                    "br": [
-                        1.0
-                    ],
-                    "dset": [
-                      "/QCD_Pt-50to80_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
-                    ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
-                    "dtag": "MC13TeV_QCD_Pt50to80_MuEnrPt5_2018",
-                    "xsec": 437504.1
                 },
                 {
                     "br": [
@@ -801,7 +757,7 @@
                     "dset": [
                       "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_2018",
                     "xsec": 106033.6648
                 },
@@ -812,7 +768,7 @@
                     "dset": [
                       "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_ext1_2018",
                     "xsec": 106033.6648
                 },
@@ -823,7 +779,7 @@
                     "dset": [
                       "/QCD_Pt-120to170_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"   
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt120to170_MuEnrPt5_2018",
                     "xsec": 25190.51514
                 },
@@ -834,7 +790,7 @@
                     "dset": [
                       "/QCD_Pt-120to170_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt120to170_ext1_MuEnrPt5_2018",
                     "xsec": 25190.51514
                 },
@@ -845,7 +801,7 @@
                     "dset": [
                       "/QCD_Pt-170to300_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_2018",
                     "xsec": 8654.49315
                 },
@@ -856,7 +812,7 @@
                     "dset": [
                       "/QCD_Pt-300to470_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_2018",
                     "xsec": 797.35269
                 },
@@ -867,7 +823,7 @@
                     "dset": [
                       "/QCD_Pt-300to470_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext3-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt300to470_ext3_MuEnrPt5_2018",
                     "xsec": 797.35269
                 },
@@ -878,7 +834,7 @@
                     "dset": [
                       "/QCD_Pt-470to600_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2018",
                     "xsec": 79.02553776
                 },
@@ -889,7 +845,7 @@
                     "dset": [
                       "/QCD_Pt-470to600_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt470to600_ext1_MuEnrPt5_2018",
                     "xsec": 79.02553776
                 },
@@ -900,7 +856,7 @@
                     "dset": [
                       "/QCD_Pt-600to800_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_2018",
                     "xsec": 25.09505908
                 },
@@ -911,7 +867,7 @@
                     "dset": [
                       "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext3-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt800to1000_ext3_MuEnrPt5_2018",
                     "xsec": 4.707368272
                 },
@@ -922,7 +878,7 @@
                     "dset": [
                       "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_2018",
                     "xsec": 1.62131692
                 }
@@ -944,7 +900,7 @@
                     "dset": [
                       "/WplusH_HToBB_WToQQ_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WplusH_HToBB_WToLNu_2018",
                     "xsec": 0.053
                 },
@@ -955,7 +911,7 @@
                     "dset": [
                       "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WplusH_HToBB_WToLNu_ext1_2018",
                     "xsec": 0.053
                 },
@@ -966,7 +922,7 @@
                     "dset": [
                       "/WminusH_HToBB_WToQQ_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WminusH_HToBB_WToLNu_2018",
                     "xsec": 0.03369
                 },
@@ -977,7 +933,7 @@
                     "dset": [
                       "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WminusH_HToBB_WToLNu_ext1_2018",
                     "xsec": 0.03369
                 },
@@ -988,7 +944,7 @@
                     "dset": [
                       "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_ZH_HToBB_ZToLL_2018",
                     "xsec": 0.04865
                 }, 
@@ -999,7 +955,7 @@
                     "dset": [
                       "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
                     ],
-                    "gtag": "102X_upgrade2018_realistic_v18",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_ZH_HToBB_ZToLL_ext1_2018",
                     "xsec": 0.04865
                 } 
@@ -1015,25 +971,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-12_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass12_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass12_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-12_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass12_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1056,25 +1012,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-15_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-15_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass15_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass15_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-15_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-15_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
+                    "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass15_2017",
-                    "xsec": 0.8594
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1097,25 +1053,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-20_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass20_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass20_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-20_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-20_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass20_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass20_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1137,25 +1093,25 @@
             "data": [
                 {   
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-25_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-25_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass25_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass25_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-25_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-25_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass25_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass25_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1171,32 +1127,32 @@
             "lwidth": 3,
             "lstyle": 5, 
             "resonance": 25,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (25)"
         },
         {
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-30_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-30_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass30_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass30_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-30_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-30_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass30_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass30_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1219,25 +1175,25 @@
             "data": [
                 {   
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-40_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-40_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass40_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass40_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-40_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-40_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass40_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass40_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1260,25 +1216,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-50_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass50_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass50_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-50_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-50_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass50_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass50_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,
@@ -1301,25 +1257,25 @@
             "data": [
                 {
                     "br": [
-                        0.2132
+                        0.3257
                     ],
                     "dset": [
-                        "/NMSSM_WHToAATo4b_M-125_M-60_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYWHToAA_AATo4B_M-60_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Wh_amass60_2017",
-                    "xsec": 1.37
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass60_2018",
+                    "xsec": "1.37*0.61"
                 },
                 {
                     "br": [
-                        0.067316
+                        0.10099
                     ],
                     "dset": [
-                        "/NMSSM_ZHToAATo4b_M-125_M-60_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+			"/SUSYZHToAA_AATo4B_M-60_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
-                    "gtag": "94X_mc2017_realistic_v14",
-                    "dtag": "MC13TeV_Zh_amass60_2017",
-                    "xsec": 0.8594
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass60_2018",
+                    "xsec": "0.8594*0.75"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -988,7 +988,7 @@
 			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
-                    "dtag": "MC13TeV_Zh_amass12_2017",
+                    "dtag": "MC13TeV_Zh_amass12_2018",
                     "xsec": "0.8594*0.75"
                 }
             ],
@@ -1029,7 +1029,7 @@
 			"/SUSYZHToAA_AATo4B_M-15_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
-                    "dtag": "MC13TeV_Zh_amass15_2017",
+                    "dtag": "MC13TeV_Zh_amass15_2018",
                     "xsec": "0.8594*0.75"
                 }
             ],

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -1086,7 +1086,7 @@
             "lcolor": 1,
             "lwidth": 3,
             "resonance": 20,
-            "spimpose": false,
+            "spimpose": true,
             "tag": "Wh (20)"
         },
         {   
@@ -1127,7 +1127,7 @@
             "lwidth": 3,
             "lstyle": 5, 
             "resonance": 25,
-            "spimpose": true,
+            "spimpose": false,
             "tag": "Wh (25)"
         },
         {


### PR DESCRIPTION
1. Update 2017 json files:
- remove low pt (<80 GeV) QCD samples;
- update new signal samples and corresponding branch ratios, cross sections.

2. Update 2018 json files:
- Update new GTs on all samples;
- remove low pt (<80 GeV) QCD samples;
- update new signal samples and corresponding branch ratios, cross sections, dtags.