### PR TITLE
Merge small MC backgrounds and blind SR in prefit plots

### DIFF
--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -1693,10 +1693,10 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       axis->GetYaxis()->SetTitleFont(42);
       axis->GetYaxis()->SetTitleSize(0.04);
 
-      if ( ((p->first).find("mu_A_SR_3b")!=std::string::npos) ||((p->first).find("mu_A_SR_4b")!=std::string::npos) ||
-       	   ((p->first).find("e_A_SR_3b")!=std::string::npos) || ((p->first).find("e_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("mumu_A_SR_3b")!=std::string::npos) || ((p->first).find("mumu_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("ee_A_SR_3b")!=std::string::npos) || ((p->first).find("ee_A_SR_4b")!=std::string::npos)) {
+      if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
+        startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
+	startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") || 
+	startsWith(p->first,"ee_A_SR_3b") || startsWith(p->first,"ee_A_SR_4b") ) {
 	
 	int bbin=axis->FindBin(0.1); //map_data[p->first]->FindBin(0.1);
        	for(unsigned int i=bbin;i<axis->GetNbinsX()+1; i++){   
@@ -1719,10 +1719,6 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       }
       
       if(blindSR){
-//	 if ( ((p->first).find("mu_A_SR_3b")!=std::string::npos) ||((p->first).find("mu_A_SR_4b")!=std::string::npos) ||
-//       	   ((p->first).find("e_A_SR_3b")!=std::string::npos) || ((p->first).find("e_A_SR_4b")!=std::string::npos) ||
-//	   ((p->first).find("mumu_A_SR_3b")!=std::string::npos) || ((p->first).find("mumu_A_SR_4b")!=std::string::npos) || 
-//	   ((p->first).find("ee_A_SR_3b")!=std::string::npos) || ((p->first).find("ee_A_SR_4b")!=std::string::npos)) {
 	 if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
        	   startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
 	   startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") || 
@@ -1858,21 +1854,20 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 
       TH1D* denSystUncH = (TH1D*)map_uncH[p->first];
       utils::root::checkSumw2(denSystUncH);
-/*      
+      
       if(blindSR){
-	if ( ((p->first).find("mu_A_SR_3b")!=std::string::npos) ||((p->first).find("mu_A_SR_4b")!=std::string::npos) ||
-       	   ((p->first).find("e_A_SR_3b")!=std::string::npos) || ((p->first).find("e_A_SR_4b")!=std::string::npos) || 
-	   ((p->first).find("mumu_A_SR_3b")!=std::string::npos) || ((p->first).find("mumu_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("ee_A_SR_3b")!=std::string::npos) || ((p->first).find("ee_A_SR_4b")!=std::string::npos)) {
+	 if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
+       	   startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
+	   startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") || 
+	   startsWith(p->first,"ee_A_SR_3b") || startsWith(p->first,"ee_A_SR_4b") ) {
 	
 	  int bbin=denSystUncH->FindBin(0.1); 
-       	  //for(unsigned int i=bbin;i<=denSystUncH->GetNbinsX()+1; i++){   
-       	  for(unsigned int i=0;i<=denSystUncH->GetNbinsX()+1; i++){   
+       	  for(unsigned int i=bbin;i<=denSystUncH->GetNbinsX()+1; i++){   
        	    denSystUncH->SetBinContent(i, 0); denSystUncH->SetBinError(i, 0);
 	  }
-	  }
+	}
       }
-*/
+
       int GPoint=0;
       TGraphErrors *denSystUnc=new TGraphErrors(denSystUncH->GetXaxis()->GetNbins()); 
       for(int xbin=1; xbin<=denSystUncH->GetXaxis()->GetNbins(); xbin++){
@@ -1935,10 +1930,10 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       dataToObs->SetMarkerSize(0.7);
       
       if(blindSR){
-	 if ( ((p->first).find("mu_A_SR_3b")!=std::string::npos) ||((p->first).find("mu_A_SR_4b")!=std::string::npos) ||
-       	   ((p->first).find("e_A_SR_3b")!=std::string::npos) || ((p->first).find("e_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("mumu_A_SR_3b")!=std::string::npos) || ((p->first).find("mumu_A_SR_4b")!=std::string::npos) || 
-	   ((p->first).find("ee_A_SR_3b")!=std::string::npos) || ((p->first).find("ee_A_SR_4b")!=std::string::npos)) {
+	if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
+       	startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
+	startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") || 
+	startsWith(p->first,"ee_A_SR_3b") || startsWith(p->first,"ee_A_SR_4b") ) {
 
 	 int bbin=axis->FindBin(0.1);
 	 int totNbins = dataToObs->GetN();
@@ -1953,10 +1948,10 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 
       
       if(blindSR){
-        if ( ((p->first).find("mu_A_SR_3b")!=std::string::npos) ||((p->first).find("mu_A_SR_4b")!=std::string::npos) ||
-       	   ((p->first).find("e_A_SR_3b")!=std::string::npos) || ((p->first).find("e_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("mumu_A_SR_3b")!=std::string::npos) || ((p->first).find("mumu_A_SR_4b")!=std::string::npos) ||
-	   ((p->first).find("ee_A_SR_3b")!=std::string::npos) || ((p->first).find("ee_A_SR_4b")!=std::string::npos)) {
+        if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
+       	startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
+	startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") || 
+	startsWith(p->first,"ee_A_SR_3b") || startsWith(p->first,"ee_A_SR_4b") ) {
 	
        	  TPave* blinding_box = new TPave(axis->GetBinLowEdge(axis->FindBin(0.1)), 0.4,axis->GetXaxis()->GetXmax(), 1.6, 0, "NB" );  
        	  blinding_box->SetFillColor(15); blinding_box->SetFillStyle(3013); blinding_box->Draw("same F");
@@ -1985,7 +1980,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       LabelText.ReplaceAll(" ","_"); 
       c[I]->SaveAs(LabelText+"_Shape.png");
       c[I]->SaveAs(LabelText+"_Shape.pdf");
-      //c[I]->SaveAs(LabelText+"_Shape.C");
+      c[I]->SaveAs(LabelText+"_Shape.C");
       delete c[I];
       
       I++;
@@ -2411,7 +2406,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 	//if(it->second.shortName.find("vhbb")!=string::npos){shapeInfo.uncScale["norm_vhbb"] = integral*0.10;}     
 	//if(it->second.shortName.find("singleto")!=string::npos){shapeInfo.uncScale["norm_singletop"] = integral*0.05;}
 	//if(it->second.shortName.find("ttbargam")!=string::npos){shapeInfo.uncScale["norm_topgzw"] = integral*0.15;} 
-	if(it->second.shortName.find("otherbkg")!=string::npos){shapeInfo.uncScale["norm_otherbkgds"] = integral*0.53;std::cout<<"setting otherbkg uncertainties to 0.53"<<std::endl;} 
+	if(it->second.shortName.find("otherbkg")!=string::npos){shapeInfo.uncScale["norm_otherbkgds"] = integral*0.53;} 
 	if(runZh) {
 	  if(it->second.shortName.find("wlnu")!=string::npos){shapeInfo.uncScale["norm_wjet"] = integral*0.02;}     
 	} else {

--- a/test/haa4b/samples2016_mergeSmallBckg.json
+++ b/test/haa4b/samples2016_mergeSmallBckg.json
@@ -1,0 +1,1861 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_MuEG2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+		},
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleElectron2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleElectron2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleElectron2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+                     "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_SingleMuon2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleMuon2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleMuon2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+			 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleMuon2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016B-03Feb2017_ver2-v2/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016C-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016D-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016E-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016F-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016G-03Feb2017-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016H-03Feb2017_ver2-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016H_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2016H-03Feb2017_ver3-v1/MINIAOD"
+                    ],
+		    "gtag": "80X_dataRun2_2016SeptRepro_v7",
+                    "dtag": "Data13TeV_DoubleEle2016H_ver3",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+		} 
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+		"haa_prod",
+                "haa_mcbased",
+		"haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 852,
+            "data": [
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZ_2016",
+                    "xsec": 17.72 
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZ_ext1_2016",
+                    "xsec": 17.72
+                },
+                 {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WW2l2nu_2016",
+                    "xsec": 12.178
+                },
+                {
+                    "br": [
+                        0.15
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWlnu2q_2016",
+                    "xsec": 49.997
+                },
+                {
+                    "br": [
+                        0.35
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWlnu2q_ext1_2016",
+                    "xsec": 49.997
+		},
+		  {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWlnu2q_ext2_2016",
+                    "xsec": 49.997
+		  },
+		  {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WWTo4Q_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WW4q_2016",
+                    "xsec": 51.723
+                },
+                {
+                     "br": [
+                        0.25
+                    ],
+                    "dset": [
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WZ_2016",
+                    "xsec": 47.13 
+                    },
+                   {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "dtag": "MC13TeV_WZ_ext1_2016",
+                    "xsec": 47.13 
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZZZ_2016",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WZZ_2016",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WWZ_2016",
+                    "xsec": 0.1651
+                },
+                {
+                   "br": [
+                     1.0
+                   ],
+                   "dset": [
+                     "/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"  
+                   ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                   "dtag": "MC13TeV_WWW_4F_2016",
+                   "xsec": 0.2086
+                }, 
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_s_2016",
+                    "xsec": 3.362
+                },
+                {
+                   "br": [                                                                                                                                         
+                        1.0  
+                    ], 
+                    "dset": [ 
+                        "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "xsec": 136.02 
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_at_2016",
+                    "xsec": 80.95
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_atW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_SingleT_tW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTGJets_2016",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [
+                        0.25
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TGJets_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+                        "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TGJets_ext1_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTWJetslnu_2016",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTZJets2l2nu_2016",
+                    "xsec": 0.2529
+                },
+                {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_ext1_2016",
+                    "xsec": 0.053 
+                },
+		 {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_2016",
+                    "xsec": 0.053
+                 },
+		 {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_ext1_2016",
+                    "xsec": 0.03369
+                 },
+		 {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_2016",
+                    "xsec": 0.03369
+                 },
+		 {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_ext1_2016",
+                    "xsec": 0.04865 
+                 },
+		 {
+                    "br": [
+                       0.5
+                     ],
+                    "dset": [ 
+		       "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_2016",
+                    "xsec": 0.04865  
+                 }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_prod",
+                "haa_mcbased"
+            ],
+            "tag": "Other Bkgds"
+        },
+       {
+            "color": 833,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased"	
+            ],
+	     "mctruthmode": 5,
+            "tag": "t#bar{t} + b#bar{b}"
+       },
+	{
+            "color": 408,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased"	
+            ],
+	     "mctruthmode": 4,
+            "tag": "t#bar{t} + c#bar{c}"
+        },
+	{
+            "color": 406,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                     ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+	        "haa_mcbased"	
+            ],
+	     "mctruthmode": 1,
+            "tag": "t#bar{t} + light"
+        }, 
+	{
+	    "color": 624,
+	    "data":[
+	        {
+		    "br": [1.0],
+		    "dset": [
+			"/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+		    ],
+		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+		    "dtag": "MC13TeV_DYJetsToLL_10to50_amcNLO_2016",
+		    "xsec": 18610
+		},
+		{
+		    "br": [1.0],
+		    "dset": [
+			"/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+		    ],
+		    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+		    "dtag": "MC13TeV_DYJetsToLL_50toInf_amcNLO_ext2_2016",
+		    "xsec": 5765.4
+		}
+	    ],
+	    "isdata": false,
+	    "keys": [
+	        "haa_prod",
+		"haa_ztoll"
+	    ],
+	    "tag": "Z#rightarrow ll"
+	},
+	{
+            "color": 624,
+            "data": [
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+		        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
+                    "xsec": 18610
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY1JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY1JetsToLL_10to50_2016",
+                    "xsec": 725
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY2JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY2JetsToLL_10to50_2016",
+                    "xsec": 394.5
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY3JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY3JetsToLL_10to50_2016",
+                    "xsec": 96.47
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY4JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY4JetsToLL_10to50_2016",
+                    "xsec": 34.84
+                },
+                {
+                    "br": [ 0.35 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+                    "xsec": 4895
+                },
+                {
+                    "br": [ 0.65 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 4895
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY1JetsToLL_50toInf_2016",
+                    "xsec": 1016
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY2JetsToLL_50toInf_2016",
+                    "xsec": 331.4
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY3JetsToLL_50toInf_2016",
+                    "xsec": 96.36
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+                        "/DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_DY4JetsToLL_50toInf_2016",
+                    "xsec": 51.4
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_ztoll",
+		"haa_mcbased"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                       0.3425
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WJets_2016",
+                    "xsec": 50690
+                },
+                {   
+                    "br": [
+                        0.6575
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_WJets_ext2_2016",
+                    "xsec": 50690
+                },
+                {   
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/W1JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W1Jets_2016",
+                    "xsec": 9493
+                },
+                {   
+                    "br": [
+                        0.496
+                    ],
+                    "dset": [
+                        "/W2JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W2Jets_2016",
+                    "xsec": 3120
+                },
+                {   
+                    "br": [
+                        0.504
+                    ],
+                    "dset": [
+                        "/W2JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W2Jets_ext1_2016",
+                    "xsec": 3120
+                },
+                {   
+                    "br": [
+                        0.335
+                    ],
+                    "dset": [
+                        "/W3JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W3Jets_2016",
+                    "xsec": 942.3
+                },
+                {   
+                    "br": [
+                        0.665
+                    ],
+                    "dset": [
+                        "/W3JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W3Jets_ext1_2016",
+                    "xsec": 942.3
+                },
+                {   
+                    "br": [
+                        0.305
+                    ],
+                    "dset": [
+                        "/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W4Jets_2016",
+                    "xsec": 524.2
+                },
+                {   
+                    "br": [
+                        0.070
+                    ],
+                    "dset": [
+                        "/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W4Jets_ext1_2016",
+                    "xsec": 524.2
+                },
+                {
+                    "br": [
+                        0.625
+                    ],
+                    "dset": [
+                        "/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_W4Jets_ext2_2016",
+                    "xsec": 524.2
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod",
+		"haa_mcbased"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 634,
+            "data": [
+                {
+                    "br": [
+                        0.461
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2016",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        0.539
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_ext1_2016",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        0.46
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2016",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        0.54
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_ext1_2016",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2016",
+                    "xsec": 18810
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2016",
+                    "xsec": 1350
+                },
+	          {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt15to20_MuEnrPt5_2016",
+                    "xsec": 3819570
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-20to30_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt20to30_MuEnrPt5_2016",
+                    "xsec": 2960198.4
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-30to50_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt30to50_MuEnrPt5_2016",
+                    "xsec": 1652471.46
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-50to80_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt50to80_MuEnrPt5_2016",
+                    "xsec": 437504.1
+                },
+                {
+                    "br": [
+                        0.584
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_2016",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        0.416
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v3/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_ext1_2016",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt120to170_MuEnrPt5_2016",
+                    "xsec": 25190.51514
+                },
+                {
+                    "br": [
+                        0.458
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_2016",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        0.542
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_ext1_2016",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        0.162
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_2016",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.336
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_ext1_2016",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.502
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_ext2_2016",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.199
+                    ],
+                    "dset": [
+                        "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.292
+                    ],
+                    "dset": [
+                        "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_ext1_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.509
+                    ],
+                    "dset": [
+                        "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_ext2_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.402
+                    ],
+                    "dset": [
+                        "/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_2016",
+                    "xsec": 25.09505908
+                },
+                {
+                    "br": [
+                        0.598
+                    ],
+                    "dset": [
+                        "/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_ext1_2016",
+                    "xsec": 25.09505908
+                },
+                {
+                    "br": [
+                        0.200
+                    ],
+                    "dset": [
+                        "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.295
+                    ],
+                    "dset": [
+                        "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_ext1_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.505
+                    ],
+                    "dset": [
+                        "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_ext2_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.293
+                    ],
+                    "dset": [
+                        "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_2016",
+                    "xsec": 1.62131692
+                },
+                {
+                    "br": [
+                        0.707
+                    ],
+                    "dset": [
+                        "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v3/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_ext1_2016",
+                    "xsec": 1.62131692
+		},     
+                {
+                    "br": [
+                        0.0002
+                    ],
+                    "dset": [
+                        "/QCD_Pt_15to20_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_15to20_bcToE_2016",
+                    "xsec": 1272980000
+                },
+                {
+                    "br": [
+                        0.00059
+                    ],
+                    "dset": [
+                        "/QCD_Pt_20to30_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_20to30_bcToE_2016",
+                    "xsec": 557627000
+                },
+                {
+                    "br": [
+                        0.00255
+                    ],
+                    "dset": [
+                        "/QCD_Pt_30to80_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_30to80_bcToE_2016",
+                    "xsec": 159068000
+                },
+                {
+                    "br": [
+                        0.01183
+                    ],
+                    "dset": [
+                        "/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_backup_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_80to170_bcToE_2016",
+                    "xsec": 3221000
+                },
+                {
+                    "br": [
+                        0.02492
+                    ],
+                    "dset": [
+                        "/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_170to250_bcToE_2016",
+                    "xsec": 105771
+                },
+                {
+                    "br": [
+                        0.03375
+                    ],
+                    "dset": [
+                        "/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM"
+                    ],
+                    "gtag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+                    "dtag": "MC13TeV_QCD_Pt_250toInf_bcToE_2016",
+                    "xsec": 21094.1
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "QCD"
+	},
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass12_2016",
+                    "xsec": "1.37*0.61"
+                },
+		            {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass12_2016",
+                    "xsec": "0.8594*0.7521"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": true,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass15_2016",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass15_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": false,
+            "tag": "Wh (15)"
+        },
+       {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass20_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass20_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+	    "lstyle":2,
+            "resonance": 20,
+            "spimpose": true,
+            "tag": "Wh (20)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass25_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass25_2016",
+                    "xsec": "0.8549*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 5, 
+            "resonance": 25,
+            "spimpose": false,
+            "tag": "Wh (25)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass30_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass30_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 6,
+            "resonance": 30,
+            "spimpose": false,
+            "tag": "Wh (30)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass40_2016",
+                    "xsec": "1.37*0.61"
+                },
+		 {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass40_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3, 
+            "lstyle": 7, 
+            "resonance": 40,
+            "spimpose": false,
+            "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass50_2016",
+                    "xsec": "1.37*0.61"
+                },
+		            {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass50_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257 
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass60_2016",
+                    "xsec": "1.37*0.61"
+                },
+		  {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass60_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 1,
+            "resonance": 60,
+            "spimpose": true,
+            "tag": "Wh (60)"
+        }
+    ]
+}

--- a/test/haa4b/samples2017_mergeSmallBckg.json
+++ b/test/haa4b/samples2017_mergeSmallBckg.json
@@ -1,0 +1,1341 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2017B-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2017B",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2017C-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2017C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2017D-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2017D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2017E-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2017E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2017F-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2017F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2017B-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleElectron2017B",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2017C-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleElectron2017C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2017D-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleElectron2017D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2017E-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleElectron2017E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2017F-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleElectron2017F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2017B-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2017B",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2017C-31Mar2018-v1/MINIAOD"
+                    ],
+                     "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2017C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2017D-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2017D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2017E-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2017E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2017F-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2017F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2017B-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2017B",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2017C-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2017C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2017D-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2017D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2017E-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2017E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2017F-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2017F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2017B-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleEle2017B",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2017C-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleEle2017C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2017D-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleEle2017D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2017E-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleEle2017E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleEG/Run2017F-31Mar2018-v1/MINIAOD"
+                    ],
+                    "gtag": "94X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleEle2017F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased",
+                "haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 852,
+            "data": [
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                       "/WW_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WW_2017",
+                    "xsec": 118.7
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                       "/WZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WZ_2017",
+                    "xsec": 47.13
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCP5_13TeV-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_ZZ_2017",
+                    "xsec": 16.523
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_ZZZ_2017",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WZZ_2017",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WWZ_2017",
+                    "xsec": 0.1651
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                        "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WWW_4F_2017",
+                    "xsec": 0.2086
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_SingleT_s_2017",
+                    "xsec": 3.354
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_t-channel_antitop_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_SingleT_t_antitop_2017",
+                    "xsec": 26.30875
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_t-channel_top_4f_inclusiveDecays_TuneCP5_13TeV-powhegV2-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_SingleT_t_top_2017",
+                    "xsec": 44.2065
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_SingleT_tW_antitop_2017",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_SingleT_tW_top_2017",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [ 0.55 ],
+                    "dset": [
+                        "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTGJets_ext1_2017",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [ 0.45 ],
+                    "dset": [
+                        "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTGJets_2017",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/TGJets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TGJets_2017",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTWJetslnu_2017",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTZJets2l2nu_2017",
+                    "xsec": 0.2529
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_2017",
+                    "xsec": 0.053
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_2017",
+                    "xsec": 0.03369
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_2017",
+                    "xsec": 0.04865
+                } 
+
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "Other Bkgds"
+        },
+        {
+            "color": 833,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		                    "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2017",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2017",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2017",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	             "haa_mcbased"	
+            ],
+            "mctruthmode": 5,
+            "tag": "t#bar{t} + b#bar{b}"
+        }, 	    
+        {
+            "color": 408,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		                    "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2017",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2017",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2017",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	             "haa_mcbased"	
+            ],
+            "mctruthmode": 4,
+            "tag": "t#bar{t} + c#bar{c}"
+        }, 	    
+        {
+            "color": 406,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		                    "/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2017",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2017",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                       "/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2017",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+	        "haa_mcbased"	
+            ],
+            "mctruthmode": 1,
+            "tag": "t#bar{t} + light"
+        }, 	    
+        {
+            "color": 624,
+            "data": [
+		{
+		    "br": [ 0.13 ],
+		    "dset":[
+		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_2017",
+		    "xsec": 5765.4 
+		},
+		{
+		    "br": [ 0.87 ],
+		    "dset":[
+		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mc2017_realistic_v14",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_ext1_2017",
+		    "xsec": 5765.4
+		}
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_ztoll"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 624,
+            "data": [
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2017",
+                    "xsec": 18610
+                },
+                {
+                    "br": [ 0.55 ],
+                    "dset": [
+                        "/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY1JetsToLL_M50_2017",
+                    "xsec": 1016
+                },
+                {
+                    "br": [ 0.45 ],
+                    "dset": [
+                        "/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY1JetsToLL_M50_ext1_2017",
+                    "xsec": 1016
+                },
+                {
+                    "br": [ 0.01 ],
+                    "dset": [
+                        "/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY2JetsToLL_M50_2017",
+                    "xsec": 331.4
+                },
+                {
+                    "br": [ 0.99 ],
+                    "dset": [
+                        "/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY2JetsToLL_M50_ext1_2017",
+                    "xsec": 331.4
+                },
+                {
+                    "br": [ 0.17 ],
+                    "dset": [
+                        "/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY3JetsToLL_M50_2017",
+                    "xsec": 96.36
+                },
+                {
+                    "br": [ 0.83 ],
+                    "dset": [
+                        "/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY3JetsToLL_M50_ext1_2017",
+                    "xsec": 96.36
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                        "/DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_v2_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DY4JetsToLL_M50_2017",
+                    "xsec": 51.4
+                },
+                {
+                    "br": [ 0.4977 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DYJetsToLL_M50_2017",
+                    "xsec": 4895
+                },
+                {
+                    "br": [ 0.5023 ],
+                    "dset": [
+                        "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017RECOSIMstep_12Apr2018_94X_mc2017_realistic_v14_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_DYJetsToLL_M50_ext1_2017",
+                    "xsec": 4895
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased",
+                "haa_ztoll"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                        0.6
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WJets_ext1_2017",
+                    "xsec": 50690
+                },
+                {
+                    "br": [
+                        0.4
+                    ],
+                    "dset": [
+                        "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_WJets_2017",
+                    "xsec": 50690
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v3/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_W1Jets_2017",
+                    "xsec": 9493
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v4/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_W2Jets_2017",
+                    "xsec": 3120
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_W3Jets_2017",
+                    "xsec": 942.3
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_new_pmx_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_W4Jets_2017",
+                    "xsec": 524.2
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod",
+		"haa_mcbased"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 634,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_EMEnriched_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2017",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_EMEnriched_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2017",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300toInf_EMEnriched_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2017",
+                    "xsec": 1350
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_2017",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-120to170_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt120to170_MuEnrPt5_2017",
+                    "xsec": 25190.51514
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-170to300_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_2017",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-300to470_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_2017",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/QCD_Pt-470to600_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2017",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.01183
+                    ],
+                    "dset": [
+                        "/QCD_Pt_80to170_bcToE_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt_80to170_bcToE_2017",
+                    "xsec": 3221000
+                },
+                {
+                    "br": [
+                        0.02492
+                    ],
+                    "dset": [
+                        "/QCD_Pt_170to250_bcToE_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt_170to250_bcToE_2017",
+                    "xsec": 105771
+                },
+                {
+                    "br": [
+                        0.03375
+                    ],
+                    "dset": [
+                        "/QCD_Pt_250toInf_bcToE_TuneCP5_13TeV_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_QCD_Pt_250toInf_bcToE_2017",
+                    "xsec": 21094.1
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "QCD"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-12_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass12_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+			0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass12_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": true,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-15_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass15_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-15_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass15_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": false,
+            "tag": "Wh (15)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-20_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass20_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-20_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass20_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "resonance": 20,
+            "spimpose": true,
+            "tag": "Wh (20)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-25_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass25_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-25_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass25_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 5, 
+            "resonance": 25,
+            "spimpose": false,
+            "tag": "Wh (25)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-30_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass30_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-30_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass30_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 6,
+            "resonance": 30,
+            "spimpose": false,
+            "tag": "Wh (30)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-40_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass40_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-40_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass40_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3, 
+            "lstyle": 7, 
+            "resonance": 40,
+            "spimpose": false,
+            "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-50_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass50_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-50_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass50_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+	{
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-60_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Wh_amass60_2017",
+                    "xsec": "1.37*0.65"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-60_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mc2017_realistic_v14",
+                    "dtag": "MC13TeV_Zh_amass60_2017",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 8,
+            "resonance": 60,
+            "spimpose": true,
+            "tag": "Wh (60)"
+        }
+    ]
+}

--- a/test/haa4b/samples2018_mergeSmallBckg.json
+++ b/test/haa4b/samples2018_mergeSmallBckg.json
@@ -1,0 +1,1264 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2018A-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2018A_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2018B-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2018B_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2018C-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_MuEG2018C_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2018D-PromptReco-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_Prompt_v14",
+                    "dtag": "Data13TeV_MuEG2018D_PromptReco_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/EGamma/Run2018A-17Sep2018-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_EGamma2018A_17Sep2018_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/EGamma/Run2018B-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_EGamma2018B_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/EGamma/Run2018C-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_EGamma2018C_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/EGamma/Run2018D-PromptReco-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_Prompt_v14",
+                    "dtag": "Data13TeV_EGamma2018D_PromptReco_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2018A-17Sep2018-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2018A_17Sep2018_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2018B-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2018B_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2018C-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_SingleMuon2018C_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2018D-PromptReco-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_Prompt_v14",
+                    "dtag": "Data13TeV_SingleMuon2018D_PromptReco_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2018A-17Sep2018-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2018A_17Sep2018_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2018B-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2018B_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2018C-17Sep2018-v1/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_v11",
+                    "dtag": "Data13TeV_DoubleMuon2018C_17Sep2018_v1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2018D-PromptReco-v2/MINIAOD"
+                    ],
+                    "gtag": "102X_dataRun2_Prompt_v14",
+                    "dtag": "Data13TeV_DoubleMuon2018D_PromptReco_v2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt",
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased",
+                "haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 852,
+            "data": [
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                       "/WW_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WW_2018",
+                    "xsec": 118.7
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/WZ_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WZ_2018",
+                    "xsec": 47.13
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/ZZ_TuneCP5_13TeV-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_ZZ_2018",
+                    "xsec": 16.523
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_ZZZ_2018",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WZZ_2018",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/WWZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WWZ_2018",
+                    "xsec": 0.1651
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+                      "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WWW_4F_2018",
+                    "xsec": 0.2086
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v3/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_SingleT_s_2018",
+                    "xsec": 3.354
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_SingleT_t_antitop_2018",
+                    "xsec": 26.30875
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_SingleT_t_top_2018",
+                    "xsec": 44.2065
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_SingleT_tW_antitop_2018",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_SingleT_tW_top_2018",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTGJets_2018",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/TGJets_TuneCP5_13TeV_amcatnlo_madspin_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TGJets_2018",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTWJetslnu_2018",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTZJets2l2nu_2018",
+                    "xsec": 0.2529
+                },
+                {
+                    "br": [
+                        0.38
+                    ],
+                    "dset": [
+                      "/WplusH_HToBB_WToQQ_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_2018",
+                    "xsec": 0.053
+                },
+                {
+                    "br": [
+                        0.62
+                    ],
+                    "dset": [
+                      "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_ext1_2018",
+                    "xsec": 0.053
+                },
+                {
+                    "br": [
+                        0.39
+                    ],
+                    "dset": [
+                      "/WminusH_HToBB_WToQQ_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_2018",
+                    "xsec": 0.03369
+                },
+                {
+                    "br": [
+                        0.61
+                    ],
+                    "dset": [
+                      "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_ext1_2018",
+                    "xsec": 0.03369
+                },
+                {
+                    "br": [
+                        0.146
+                    ],
+                    "dset": [
+                      "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_2018",
+                    "xsec": 0.04865
+                }, 
+                {
+                    "br": [
+                        0.854
+                    ],
+                    "dset": [
+                      "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_ext1_2018",
+                    "xsec": 0.04865
+                } 
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "Other Bkgds"
+        },
+        {
+            "color": 833,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+                      "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2018",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased"	
+            ],
+            "mctruthmode": 5,
+            "tag": "t#bar{t} + b#bar{b}"
+        }, 	    
+        {
+            "color": 408,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+                      "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2018",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased"	
+            ],
+            "mctruthmode": 4,
+            "tag": "t#bar{t} + c#bar{c}"
+        }, 	    
+        {
+            "color": 406,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+                      "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTTo2L2Nu_powheg_2018",
+                    "xsec": 88.29
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToSemiLeptonic_powheg_2018",
+                    "xsec": 365.34
+                },
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [
+                      "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                     ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_TTToHadronic_powheg_2018",
+                    "xsec": 377.96
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+	        "haa_mcbased"	
+            ],
+            "mctruthmode": 1,
+            "tag": "t#bar{t} + light"
+        }, 	    
+        {
+            "color": 624,
+            "data": [
+		{
+		    "br": [ 0.005 ],
+		    "dset": [
+		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+		    ],
+		    "gtag": "102X_upgrade2018_realistic_v19",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_2018",
+		    "xsec": 5765.4
+		},
+		{
+		    "br": [ 0.995 ],
+		    "dset": [
+		        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext2-v1/MINIAODSIM"
+		    ],
+		    "gtag": "102X_upgrade2018_realistic_v19",
+		    "dtag": "MC13TeV_DYJetsToLL_M50_amcNLO_ext2_2018",
+		    "xsec": 5765.4
+		}
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_ztoll"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 624,
+            "data": [
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2018",
+                    "xsec": 18610
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DY1JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DY1JetsToLL_M50_2018",
+                    "xsec": 725
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DY2JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DY2JetsToLL_M50_2018",
+                    "xsec": 394.5
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DY3JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DY3JetsToLL_M50_2018",
+                    "xsec": 96.47
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DY4JetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DY4JetsToLL_M50_2018",
+                    "xsec": 40.44
+                },
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+                      "/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_DYJetsToLL_M50_2018",
+                    "xsec": 6100.8
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased",
+                "haa_ztoll"
+            ],
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_WJets_2018",
+                    "xsec": 50960
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_W1Jets_2018",
+                    "xsec": 9493
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_W2Jets_2018",
+                    "xsec": 3120
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_W3Jets_2018",
+                    "xsec": 942.3
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_W4Jets_2018",
+                    "xsec": 524.2
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod",
+		"haa_mcbased"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 634,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-80to120_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2018",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-120to170_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2018",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-170to300_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2018",
+                    "xsec": 18810
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-300toInf_EMEnriched_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2018",
+                    "xsec": 1350
+                },
+                {
+                    "br": [
+                        0.02
+                    ],
+                    "dset": [
+                      "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_2018",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        0.98
+                    ],
+                    "dset": [
+                      "/QCD_Pt-80to120_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_ext1_2018",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        0.03
+                    ],
+                    "dset": [
+                      "/QCD_Pt-120to170_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"   
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt120to170_MuEnrPt5_2018",
+                    "xsec": 25190.51514
+                },
+                {
+                    "br": [
+                        0.97
+                    ],
+                    "dset": [
+                      "/QCD_Pt-120to170_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt120to170_ext1_MuEnrPt5_2018",
+                    "xsec": 25190.51514
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-170to300_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_2018",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        0.017
+                    ],
+                    "dset": [
+                      "/QCD_Pt-300to470_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v3/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_2018",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.983
+                    ],
+                    "dset": [
+                      "/QCD_Pt-300to470_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt300to470_ext3_MuEnrPt5_2018",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.024
+                    ],
+                    "dset": [
+                      "/QCD_Pt-470to600_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2018",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.976
+                    ],
+                    "dset": [
+                      "/QCD_Pt-470to600_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt470to600_ext1_MuEnrPt5_2018",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-600to800_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_2018",
+                    "xsec": 25.09505908
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15_ext3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_ext3_MuEnrPt5_2018",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                      "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCP5_13TeV_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_2018",
+                    "xsec": 1.62131692
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "QCD"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-12_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass12_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-12_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass12_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": true,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-15_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass15_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-15_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass15_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": false,
+            "tag": "Wh (15)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-20_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass20_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-20_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass20_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "resonance": 20,
+            "spimpose": true,
+            "tag": "Wh (20)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-25_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass25_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-25_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass25_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 5, 
+            "resonance": 25,
+            "spimpose": false,
+            "tag": "Wh (25)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-30_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass30_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-30_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass30_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 6,
+            "resonance": 30,
+            "spimpose": false,
+            "tag": "Wh (30)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-40_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass40_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-40_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass40_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3, 
+            "lstyle": 7, 
+            "resonance": 40,
+            "spimpose": false,
+            "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-50_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass50_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-50_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass50_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-60_TuneCP5_PSweights_13TeV-madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Wh_amass60_2018",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-60_TuneCP5_PSweight_13TeV_madgraph_pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM"
+                    ],
+                    "gtag": "102X_upgrade2018_realistic_v19",
+                    "dtag": "MC13TeV_Zh_amass60_2018",
+                    "xsec": "0.8594*0.75"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 8,
+            "resonance": 60,
+            "spimpose": true,
+            "tag": "Wh (60)"
+        }
+    ]
+}


### PR DESCRIPTION
1. Add new json files where small MC backgrounds are merged into one called 'Other Other Bkgds' for each year 2016-2018;
2. Update computeLimit.cc to do data-driven QCD estimation and calculate uncertainties correctly for the merged MC source 'Other Other Bkgds';
3. Update computeLimit to blind SR regions on the bdt shape plots correctly.