### PR TITLE
Adding back passing electron ID requirement when running qcd option

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -1333,7 +1333,7 @@ int main(int argc, char* argv[])
 	  if (abs(lepid)==11) {
 	    lep_threshold=ele_threshold_;
 	    if(!runQCD)hasTightIdandIso = (ilep.passIdEl && ilep.passIsoEl);   
-            //else hasTightIdandIso = ilep.passIdEl;
+            else hasTightIdandIso = ilep.passIdEl;
 	    if ( (ilep.passIdEl) && (ilep.pt()>lep_threshold) ) allLeptons.push_back(ilep);
 	  } else if (abs(lepid)==13) {
 	    lep_threshold=mu_threshold_;


### PR DESCRIPTION
Adding back passing electron ID requirement when running qcd option analysis.