### PR TITLE
Require loose electron ID selection and fix the electron Isolation cut

### DIFF
--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -107,7 +107,6 @@ float statBinByBin = -1;
 bool useLogy = true;
 bool blindSR = false;
 double lumi = -1;
-int signalScale = 1;
 
 bool dirtyFix1 = false;
 bool dirtyFix2 = false;
@@ -508,7 +507,6 @@ void printHelp()
   printf("--minSignalYield   --> use this to specify the minimum Signal yield you want in each channel)\n");
   printf("--signalSufix --> use this flag to specify a suffix string that should be added to the signal 'histo' histogram\n");
   printf("--signalTag   --> use this flag to specify a tag that should be present in signal sample name\n");
-  printf("--signalScale   --> use this flag to specify a Scale applied on signal\n");
   printf("--rebin         --> rebin the histogram\n");
   printf("--statBinByBin --> make bin by bin statistical uncertainty\n");
   printf("--inclusive  --> merge bins to make the analysis inclusive\n");
@@ -582,7 +580,6 @@ int main(int argc, char* argv[])
     else if(arg.find("--dirtyFix1")    !=string::npos) { dirtyFix1=true; printf("dirtyFix1 = True\n");}
     else if(arg.find("--signalSufix") !=string::npos) { signalSufix = argv[i+1]; i++; printf("signalSufix '%s' will be used\n", signalSufix.Data()); }
     else if(arg.find("--signalTag") !=string::npos) { signalTag = argv[i+1]; i++; printf("signalTag '%s' will be used\n", signalTag.c_str()); }
-    else if(arg.find("--signalScale") !=string::npos) { sscanf(argv[i+1],"%d",&signalScale); i++; printf("signalScale = %d\n", signalScale);}
     else if(arg.find("--rebin")    !=string::npos && i+1<argc)  { sscanf(argv[i+1],"%i",&rebinVal); i++; printf("rebin = %i\n", rebinVal);}
     else if(arg.find("--BackExtrapol")    !=string::npos) { BackExtrapol=true; printf("BackExtrapol = True\n");}
     else if(arg.find("--statBinByBin")    !=string::npos) { sscanf(argv[i+1],"%f",&statBinByBin); i++; printf("statBinByBin = %f\n", statBinByBin);}
@@ -1062,13 +1059,9 @@ void AllInfo_t::doBackgroundSubtraction(FILE* pFile,std::vector<TString>& selCh,
     TH1* hDD_D = procInfo_DD.channels.find((binName+"_"+chData->second.bin.c_str()).Data())->second.shapes[mainHisto.Data()].histo();
     binName.ReplaceAll("D_","B_");    
     TH1* hDD_B = procInfo_DD.channels.find((binName+"_"+chData->second.bin.c_str()).Data())->second.shapes[mainHisto.Data()].histo();  
-    binName.ReplaceAll("B_","A_");
-    TH1* _hDD_A = procInfo_DD.channels.find((binName+"_"+chData->second.bin.c_str()).Data())->second.shapes[mainHisto.Data()].histo();  
-    TH1* hDD_A = new TH1F("","",30,-0.3,0.3); 
-    if(_hDD_A) hDD_A = (TH1*) _hDD_A->Clone();
     
     
-    binName.ReplaceAll("A_","");   
+    binName.ReplaceAll("B_","");   
 
     //compute alpha
     double alpha=0 ,alpha_err=0;
@@ -1116,12 +1109,6 @@ void AllInfo_t::doBackgroundSubtraction(FILE* pFile,std::vector<TString>& selCh,
 
     //save values for printout
     double valDD, valDD_err;
-    if(binName.Contains("e_")){ // Electron channels, take MC QCD
-      hDD->Reset();
-      if(hDD_A) {hDD->Add(hDD_A, 1.0);}
-      datadriven_qcd_Syst = 1.0;
-      std::cout << "valDD: " << hDD->IntegralAndError(1,hDD->GetXaxis()->GetNbins()+1,valDD_err) << std::endl;
-    }
     //valDD = hDD->IntegralAndError(1,hDD->GetXaxis()->GetNbins()+1,valDD_err); if(valDD<1E-6){valDD=0.0; valDD_err=0.0;}
     valDD = hDD->IntegralAndError(1,hDD->GetXaxis()->GetNbins()+1,valDD_err); if(valDD<1E-3){valDD=0.0; valDD_err=0.0;}
 
@@ -1733,14 +1720,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       map_unc [p->first]->Draw("2 same");
       for(unsigned int i=0;i<map_signals[p->first].size();i++){
 	TH1* hs= map_signals[p->first][i];
-        if (hs) {
-	  if ( startsWith(p->first,"mu_A_SR_3b") || startsWith(p->first,"mu_A_SR_4b") ||
-		  startsWith(p->first,"e_A_SR_3b") || startsWith(p->first,"e_A_SR_4b") ||
-		  startsWith(p->first,"mumu_A_SR_3b") || startsWith(p->first,"mumu_A_SR_4b") ||
-		  startsWith(p->first,"ee_A_SR_3b") || startsWith(p->first,"ee_A_SR_4b") ) 
-	    hs->Scale(signalScale);
-	  hs->Draw("HIST same");
-	}
+        if (hs) hs->Draw("HIST same");
       }
       
       if(blindSR){

--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -991,7 +991,9 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
        ev.mn=0;
        //       for (std::vector<pat::Muon >::const_iterator mu = muons.begin(); mu!=muons.end(); mu++) 
        for(pat::Muon &mu : muons) {
-	 if(mu.pt() < 10.) continue;
+	 if(mu.pt() < 10. || fabs(mu.eta()) > 2.5) continue;
+
+
 	 bool passId;
 	 if(is2017 || is2018) passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::Fall17v2);
 	 else passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::ICHEP16Cut);
@@ -1078,12 +1080,14 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
        for (pat::Electron &el : electrons) {
        //       for( View<pat::ElectronCollection>::const_iterator el = electrons.begin(); el != electrons.end(); el++ ) 
 	 float pt_ = el.pt();
-	 if (pt_ < 15.) continue;
+	 float eta_ = fabs(el.eta());
+
+	 if (pt_ < 15. || eta_ > 2.5) continue;
 
 	 bool passId;
-	 if(is2018) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v2, rho);
-	 else if(is2017) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v1, rho);
-	 else passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut, rho);
+	 if(is2018) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v2, rho);
+	 else if(is2017) passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v1, rho);
+	 else passId=patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::ICHEP16Cut, rho);
 	 if(!passId) continue;
 
 	 // Kinematics
@@ -1112,14 +1116,16 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	 if(is2018){
 	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v2, rho);
 	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v2, rho);
+	   ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::Fall17v2, &relIso_el, (is2017 << 0) | (is2018 << 1), rho) ;
 	 }else if(is2017){
 	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::Fall17v1, rho);
 	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::Fall17v1, rho);
+	   ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::Fall17v1, &relIso_el, (is2017 << 0) | (is2018 << 1), rho) ;
 	 } else{ //2016
 	   ev.en_passId[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Tight, patUtils::CutVersion::ICHEP16Cut, rho);
 	   ev.en_passIdLoose[ev.en] = patUtils::passId(el, vtx[0], patUtils::llvvElecId::Loose, patUtils::CutVersion::ICHEP16Cut, rho);
+	   ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, &relIso_el, (is2017 << 0) | (is2018 << 1), rho) ;
 	 }
-	 ev.en_passIso[ev.en] = patUtils::passIso(el, patUtils::llvvElecIso::Tight, patUtils::CutVersion::ICHEP16Cut, &relIso_el, (is2017 << 0) | (is2018 << 1), rho) ;
          ev.en_relIso[ev.en] = relIso_el;
 
 	 const EcalRecHitCollection* recHits = (el.isEB()) ? recHitCollectionEBHandle.product() : recHitCollectionEEHandle.product();

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -908,7 +908,38 @@ namespace patUtils
                 }
              break;
 
-          default:
+          case CutVersion::Fall17v1 :
+          case CutVersion::Fall17v2 :
+      	  // ICHEP16 or Moriond17 selection, conditions: PU20 bx25
+               switch(IsoLevel){
+                     case llvvElecIso::Veto :
+                        if( barrel && relIso < 0.198+0.506/el.pt()    ) return true;
+                        if( endcap && relIso < 0.203+0.963/el.pt()    ) return true;
+                        break;
+
+                     case llvvElecIso::Loose :
+                        if( barrel && relIso < 0.112+0.506/el.pt()   ) return true;
+                        if( endcap && relIso < 0.108+0.963/el.pt()    ) return true;
+                        break;
+
+                     case llvvElecIso::Medium :
+                        if( barrel && relIso < 0.0478+0.506/el.pt()   ) return true;
+                        if( endcap && relIso < 0.0658+0.963/el.pt()   ) return true;
+                        break;
+
+                     case llvvElecIso::Tight :
+                        if( barrel && relIso < 0.0287+0.506/el.pt()   ) return true;
+                        if( endcap && relIso < 0.0445+0.963/el.pt()   ) return true;
+                        break;
+
+                     default:
+                        printf("FIXME ElectronIso llvvElectronIso::%i is unkown\n", IsoLevel);
+                        return false;
+                        break;
+                }
+             break;
+          
+	  default:
              printf("FIXME ElectronIsolation  CutVersion::%i is unkown\n", cutVersion);
              return false;
              break;


### PR DESCRIPTION
1. Store events with loose electron ID selection;
2. Fix the electron isolation cut for 2017 and 2018