### PR TITLE
Update on the Ntuple skimming

### DIFF
--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -995,8 +995,10 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 
 
 	 bool passId;
-	 if(is2017 || is2018) passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::Fall17v2);
-	 else passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::ICHEP16Cut);
+	 //if(is2017 || is2018) passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::Fall17v2);
+	 //else passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::ICHEP16Cut);
+	 if(is2017 || is2018) passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::Fall17v2);
+	 else passId=patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::ICHEP16Cut);
 	 if(!passId) continue;
 
 	 ev.mn_px[ev.mn] = mu.px();
@@ -1046,7 +1048,7 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	 }
 	 else{//2016
 	   ev.mn_passId[ev.mn]  = patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Tight, patUtils::CutVersion::ICHEP16Cut);
-	   ev.mn_passIdLoose[ev.mn] = patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Medium, patUtils::CutVersion::ICHEP16Cut);
+	   ev.mn_passIdLoose[ev.mn] = patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Loose, patUtils::CutVersion::ICHEP16Cut);
 	   ev.mn_passSoftMuon[ev.mn] = patUtils::passId(mu, vtx[0], patUtils::llvvMuonId::Soft, patUtils::CutVersion::ICHEP16Cut);
 	   ev.mn_passIso[ev.mn] = patUtils::passIso(mu, patUtils::llvvMuonIso::Tight, patUtils::CutVersion::ICHEP16Cut, &relIso_mu, &trkrelIso);
 	 }
@@ -1279,7 +1281,7 @@ mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSetup)
 	 ev.jet++;
          ijet++ ;
        }
-       if((ijet2<3)) return;
+       if((ijet2<2)) return;
        //       if(nCSVLtags<2) return;
        //
        // jet selection (AK8Jets)

--- a/src/DataEvtSummaryHandler.cc
+++ b/src/DataEvtSummaryHandler.cc
@@ -287,7 +287,7 @@ bool DataEvtSummaryHandler::initTree(TTree *t)
     t_->Branch("sv_ndof"         , evSummary_.sv_ndof          , "sv_ndof[sv]/F" ) ;
     t_->Branch("sv_mc_nbh_moms"  , evSummary_.sv_mc_nbh_moms   , "sv_mc_nbh_moms[sv]/I" ) ;
     t_->Branch("sv_mc_nbh_daus"  , evSummary_.sv_mc_nbh_daus   , "sv_mc_nbh_daus[sv]/I" ) ;
-    t_->Branch("sv_mc_mcbh_ind"  , evSummary_.sv_mc_mcbh_ind   , "sv_mc_mcbh_ind[sv]/I" ) ;
+//    t_->Branch("sv_mc_mcbh_ind"  , evSummary_.sv_mc_mcbh_ind   , "sv_mc_mcbh_ind[sv]/I" ) ;
 
 
     //fjet (ak8PFJetsCHS)
@@ -424,12 +424,12 @@ bool DataEvtSummaryHandler::attachToTree(TTree *t)
 
 
     //gen ground state B hadrons
-    t_->SetBranchAddress("mcbh",          &evSummary_.mcbh   );
-    t_->SetBranchAddress("mcbh_px",       evSummary_.mcbh_px );
-    t_->SetBranchAddress("mcbh_py",       evSummary_.mcbh_py );
-    t_->SetBranchAddress("mcbh_pz",       evSummary_.mcbh_pz );
-    t_->SetBranchAddress("mcbh_en",       evSummary_.mcbh_en );
-    t_->SetBranchAddress("mcbh_id",       evSummary_.mcbh_id );
+//    t_->SetBranchAddress("mcbh",          &evSummary_.mcbh   );
+//    t_->SetBranchAddress("mcbh_px",       evSummary_.mcbh_px );
+//    t_->SetBranchAddress("mcbh_py",       evSummary_.mcbh_py );
+//    t_->SetBranchAddress("mcbh_pz",       evSummary_.mcbh_pz );
+//    t_->SetBranchAddress("mcbh_en",       evSummary_.mcbh_en );
+//    t_->SetBranchAddress("mcbh_id",       evSummary_.mcbh_id );
 
 
 
@@ -630,7 +630,7 @@ bool DataEvtSummaryHandler::attachToTree(TTree *t)
     t_->SetBranchAddress("sv_ndof"         , evSummary_.sv_ndof           ) ;
     t_->SetBranchAddress("sv_mc_nbh_moms"  , evSummary_.sv_mc_nbh_moms    ) ;
     t_->SetBranchAddress("sv_mc_nbh_daus"  , evSummary_.sv_mc_nbh_daus    ) ;
-    t_->SetBranchAddress("sv_mc_mcbh_ind"  , evSummary_.sv_mc_mcbh_ind    ) ;
+//    t_->SetBranchAddress("sv_mc_mcbh_ind"  , evSummary_.sv_mc_mcbh_ind    ) ;
 
 
     /*

--- a/src/DataEvtSummaryHandler.cc
+++ b/src/DataEvtSummaryHandler.cc
@@ -83,12 +83,12 @@ bool DataEvtSummaryHandler::initTree(TTree *t)
     t_->Branch("mc_momidx",     evSummary_.mc_momidx,       "mc_momidx[nmcparticles]/I");
 
     //gen ground state B hadrons
-    t_->Branch("mcbh",          &evSummary_.mcbh,           "mcbh/I");
-    t_->Branch("mcbh_px",       evSummary_.mcbh_px,         "mcbh_px[mcbh]/F");
-    t_->Branch("mcbh_py",       evSummary_.mcbh_py,         "mcbh_py[mcbh]/F");
-    t_->Branch("mcbh_pz",       evSummary_.mcbh_pz,         "mcbh_pz[mcbh]/F");
-    t_->Branch("mcbh_en",       evSummary_.mcbh_en,         "mcbh_en[mcbh]/F");
-    t_->Branch("mcbh_id",       evSummary_.mcbh_id,         "mcbh_en[mcbh]/I");
+//    t_->Branch("mcbh",          &evSummary_.mcbh,           "mcbh/I");
+//    t_->Branch("mcbh_px",       evSummary_.mcbh_px,         "mcbh_px[mcbh]/F");
+//    t_->Branch("mcbh_py",       evSummary_.mcbh_py,         "mcbh_py[mcbh]/F");
+//    t_->Branch("mcbh_pz",       evSummary_.mcbh_pz,         "mcbh_pz[mcbh]/F");
+//    t_->Branch("mcbh_en",       evSummary_.mcbh_en,         "mcbh_en[mcbh]/F");
+//    t_->Branch("mcbh_id",       evSummary_.mcbh_id,         "mcbh_en[mcbh]/I");
 
     /* tmp
     // gen jets

--- a/src/PatUtils.cc
+++ b/src/PatUtils.cc
@@ -558,6 +558,7 @@ namespace patUtils
     //for muon Id look here: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#LooseMuon
 
     // Spring15 selection
+    bool goodGlob = mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 3 && mu.combinedQuality().chi2LocalPosition < 12 && mu.combinedQuality().trkKink < 20;
     switch(cutVersion){
     case CutVersion::Spring15Cut25ns :
 
@@ -610,6 +611,10 @@ namespace patUtils
               if(muon::isGoodMuon(mu, muon::TMOneStationTight) && mu.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 && mu.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0 &&
                  fabs(mu.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(mu.innerTrack()->dz(vtx.position())) < 20.) return true;
               break;
+	
+	    case llvvMuonId::Medium :
+	      if (muon::isLooseMuon(mu) && mu.innerTrack()->validFraction() > 0.8 &&  muon::segmentCompatibility(mu) > (goodGlob ? 0.303 : 0.451)) return true;
+	      break;
 
             case llvvMuonId::Tight :
               if( mu.isPFMuon() && mu.isGlobalMuon() && mu.globalTrack()->normalizedChi2() < 10. && mu.globalTrack()->hitPattern().numberOfValidMuonHits() > 0. && mu.numberOfMatchedStations() > 1 &&


### PR DESCRIPTION
1. Add the implementation of Medium Muon ID for 2016;
2. Require Muon ID to be tight;
3. Loose the number of jets to be >= 2;
4. Discard the b hadron infos in the tree;