### PR TITLE
Fix and updates on GOF and limits

### DIFF
--- a/bin/common/computeLimit.cc
+++ b/bin/common/computeLimit.cc
@@ -2567,7 +2567,7 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
       dcName.ReplaceAll(".root","_"+TString(C->first.c_str())+".dat");
       //      dcName.ReplaceAll("_qcdB","_qcdB");  
 
-      combinedcard += (C->first+"=").c_str()+dcName+" ";
+      if(C->first.find("emu")==string::npos) combinedcard += (C->first+"=").c_str()+dcName+" ";
       if(runZh) {
 	if(C->first.find("ee"  )!=string::npos)eecard   += (C->first+"=").c_str()+dcName+" ";
 	if(C->first.find("mumu")!=string::npos)mumucard += (C->first+"=").c_str()+dcName+" ";
@@ -2984,15 +2984,16 @@ void AllInfo_t::getYieldsFromShape(FILE* pFile, std::vector<TString>& selCh, str
 	    //	    printf("Now going to rebinMainHisto of: %s\n",jetBin.Data());
 
 	    if(jetBin.Contains("3b")){
-	      //	      double xbins[] = {-0.30, -0.18, -0.06, 0.06, 0.18, 0.30};  
-	      double xbins[] = {-0.30, -0.1, 0.1, 0.20, 0.24, 0.30};     
-	      if(runZh)  {xbins[3]=0.16; xbins[4]=0.20;} // xbins = {-0.30, -0.1, 0.1, 0.20, 0.22, 0.30};     
+	      //double xbins[] = {-0.35, -0.13, 0.09, 0.17, 0.23, 0.35};     
+	      double xbins[] = {-0.31, -0.09, 0.09, 0.19, 0.21, 0.35};     
+	      if(runZh)  {xbins[0]=-0.31;xbins[1]=-0.09;xbins[2]=0.09;xbins[3]=0.17; xbins[4]=0.19;xbins[5]=0.35;} // xbins = {-0.30, -0.1, 0.1, 0.20, 0.22, 0.30};     
 	      int nbins=sizeof(xbins)/sizeof(double);    
 	      unc->second = histo->Rebin(nbins-1, histo->GetName(), (double*)xbins);  
 	      utils::root::fixExtremities(unc->second, false, true); 
 	    }else if(jetBin.Contains("4b")){ 
-	      double xbins[] = {-0.30, -0.1, 0.1, 0.14, 0.22, 0.30}; 
-	      if(runZh) {xbins[3]=0.16; xbins[4]=0.22;} // xbins = {-0.30, -0.1, 0.1, 0.22, 0.24, 0.30};
+	      //double xbins[] = {-0.35, -0.13, 0.09, 0.17, 0.21, 0.35}; 
+	      double xbins[] = {-0.31, -0.09, 0.07, 0.11, 0.15, 0.35}; 
+	      if(runZh) {xbins[0]=-0.31;xbins[1]=-0.09;xbins[2]=0.09;xbins[3]=0.15; xbins[4]=0.21;xbins[5]=0.35;} // xbins = {-0.30, -0.1, 0.1, 0.22, 0.24, 0.30};
 	      int nbins=sizeof(xbins)/sizeof(double);
 	      unc->second = histo->Rebin(nbins-1, histo->GetName(), (double*)xbins); 
 	      utils::root::fixExtremities(unc->second, false, true); 

--- a/test/haa4b/computeLimit/GOF/CMS_lumi.py
+++ b/test/haa4b/computeLimit/GOF/CMS_lumi.py
@@ -1,0 +1,159 @@
+import ROOT as rt
+
+# CMS_lumi
+#   Initiated by: Gautier Hamel de Monchenault (Saclay)
+#   Translated in Python by: Joshua Hardenbrook (Princeton)
+#   Updated by:   Dinko Ferencek (Rutgers)
+#
+
+cmsText     = "CMS";
+cmsTextFont   = 61  
+
+writeExtraText = True
+extraText   = "Preliminary"
+extraTextFont = 52 
+
+lumiTextSize     = 0.6
+lumiTextOffset   = 0.2
+
+cmsTextSize      = 0.75
+cmsTextOffset    = 0.1
+
+relPosX    = 0.045
+relPosY    = 0.035
+relExtraDY = 1.2
+
+extraOverCmsTextSize  = 0.76
+
+lumi_13TeV = "20.1 fb^{-1}"
+lumi_8TeV  = "19.7 fb^{-1}" 
+lumi_7TeV  = "5.1 fb^{-1}"
+lumi_sqrtS = ""
+
+drawLogo      = False
+
+def CMS_lumi(pad,  iPeriod,  iPosX ):
+    outOfFrame    = False
+    if(iPosX/10==0 ): outOfFrame = True
+
+    alignY_=3
+    alignX_=2
+    if( iPosX/10==0 ): alignX_=1
+    if( iPosX==0    ): alignY_=1
+    if( iPosX/10==1 ): alignX_=1
+    if( iPosX/10==2 ): alignX_=2
+    if( iPosX/10==3 ): alignX_=3
+    align_ = 10*alignX_ + alignY_
+
+    H = pad.GetWh()
+    W = pad.GetWw()
+    l = pad.GetLeftMargin()
+    t = pad.GetTopMargin()
+    r = pad.GetRightMargin()
+    b = pad.GetBottomMargin()
+    e = 0.025
+
+    pad.cd()
+
+    lumiText = ""
+    if( iPeriod==1 ):
+        lumiText += lumi_7TeV
+        lumiText += " (7 TeV)"
+    elif ( iPeriod==2 ):
+        lumiText += lumi_8TeV
+        lumiText += " (8 TeV)"
+
+    elif( iPeriod==3 ):      
+        lumiText = lumi_8TeV 
+        lumiText += " (8 TeV)"
+        lumiText += " + "
+        lumiText += lumi_7TeV
+        lumiText += " (7 TeV)"
+    elif ( iPeriod==4 ):
+        lumiText += lumi_13TeV
+        lumiText += " (13 TeV)"
+    elif ( iPeriod==7 ):
+        if( outOfFrame ):lumiText += "#scale[0.85]{"
+        lumiText += lumi_13TeV 
+        lumiText += " (13 TeV)"
+        lumiText += " + "
+        lumiText += lumi_8TeV 
+        lumiText += " (8 TeV)"
+        lumiText += " + "
+        lumiText += lumi_7TeV
+        lumiText += " (7 TeV)"
+        if( outOfFrame): lumiText += "}"
+    elif ( iPeriod==12 ):
+        lumiText += "8 TeV"
+    elif ( iPeriod==0 ):
+        lumiText += lumi_sqrtS
+            
+    print lumiText
+
+    latex = rt.TLatex()
+    latex.SetNDC()
+    latex.SetTextAngle(0)
+    latex.SetTextColor(rt.kBlack)    
+    
+    extraTextSize = extraOverCmsTextSize*cmsTextSize
+    
+    latex.SetTextFont(42)
+    latex.SetTextAlign(31) 
+    latex.SetTextSize(lumiTextSize*t)    
+
+    latex.DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText)
+
+    if( outOfFrame ):
+        latex.SetTextFont(cmsTextFont)
+        latex.SetTextAlign(11) 
+        latex.SetTextSize(cmsTextSize*t)    
+        latex.DrawLatex(l,1-t+lumiTextOffset*t,cmsText)
+  
+    pad.cd()
+
+    posX_ = 0
+    if( iPosX%10<=1 ):
+        posX_ =   l + relPosX*(1-l-r)
+    elif( iPosX%10==2 ):
+        posX_ =  l + 0.5*(1-l-r)
+    elif( iPosX%10==3 ):
+        posX_ =  1-r - relPosX*(1-l-r)
+
+    posY_ = 1-t - relPosY*(1-t-b)
+
+    if( not outOfFrame ):
+        if( drawLogo ):
+            posX_ =   l + 0.045*(1-l-r)*W/H
+            posY_ = 1-t - 0.045*(1-t-b)
+            xl_0 = posX_
+            yl_0 = posY_ - 0.15
+            xl_1 = posX_ + 0.15*H/W
+            yl_1 = posY_
+            CMS_logo = rt.TASImage("CMS-BW-label.png")
+            pad_logo =  rt.TPad("logo","logo", xl_0, yl_0, xl_1, yl_1 )
+            pad_logo.Draw()
+            pad_logo.cd()
+            CMS_logo.Draw("X")
+            pad_logo.Modified()
+            pad.cd()          
+        else:
+            latex.SetTextFont(cmsTextFont)
+            latex.SetTextSize(cmsTextSize*t)
+            latex.SetTextAlign(align_)
+            latex.DrawLatex(posX_, posY_, cmsText)
+            if( writeExtraText ) :
+                latex.SetTextFont(extraTextFont)
+                latex.SetTextAlign(align_)
+                latex.SetTextSize(extraTextSize*t)
+                latex.DrawLatex(posX_, posY_- relExtraDY*cmsTextSize*t, extraText)
+    elif( writeExtraText ):
+        if( iPosX==0):
+            posX_ =   l +  relPosX*(1-l-r)
+            posY_ =   1-t+lumiTextOffset*t
+
+        latex.SetTextFont(extraTextFont)
+        latex.SetTextSize(extraTextSize*t)
+        latex.SetTextAlign(align_)
+        latex.DrawLatex(posX_, posY_, extraText)      
+
+    pad.Update()

--- a/test/haa4b/computeLimit/GOF/README
+++ b/test/haa4b/computeLimit/GOF/README
@@ -1,0 +1,9 @@
+## Run GOF
+1. make sure first you have the limit cards directory by running for example: python optimize_haa.py -p 4.0
+2. Generate observed test statistics and expected distribution:
+   Configure your cards directory in the script goodnessfit.sh, and make sure comment out the Zh or Wh part of code
+> sh ./goodnessfit.sh
+3. Plot:
+   Configure your cards directory in the script plotGOF.py
+> python plotGOF.py
+   GOF.pdf will be produced under the current folder.

--- a/test/haa4b/computeLimit/GOF/goodnessfit.sh
+++ b/test/haa4b/computeLimit/GOF/goodnessfit.sh
@@ -1,0 +1,25 @@
+# cd to your card directory
+cd /afs/cern.ch/work/y/yuanc/Analysis/H2a4b/CMSSW_10_2_13/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/JOBS/SB13TeV_SM_Zh_backup/test/out_60_new
+
+
+######## ZH #########
+tt_e=`cat simfit_m60_e.txt | grep 'tt_norm_e' | awk '{print $4;}'`;
+tt_mu=`cat simfit_m60_mu.txt | grep 'tt_norm_mu' | awk '{print $4;}'`;
+v_3b_e=`cat simfit_m60_e.txt | grep 'z_norm_3b_e' | awk '{print $4;}'`;
+v_4b_e=`cat simfit_m60_e.txt | grep 'z_norm_4b_e' | awk '{print $4;}'`;
+v_3b_mu=`cat simfit_m60_mu.txt | grep 'z_norm_3b_mu' | awk '{print $4;}'`;
+v_4b_mu=`cat simfit_m60_mu.txt | grep 'z_norm_4b_mu' | awk '{print $4;}'`;
+
+combine -M GoodnessOfFit -d workspace.root --algo=saturated --setParametersForFit mask_ee_A_SR_3b=1,mask_ee_A_SR_4b=1,mask_mumu_A_SR_3b=1,mask_mumu_A_SR_4b=1 --setParametersForEval mask_ee_A_SR_3b=0,mask_ee_A_SR_4b=0,mask_mumu_A_SR_3b=0,mask_mumu_A_SR_4b=0 --freezeParameters r,tt_norm_e,z_norm_3b_e,z_norm_4b_e,tt_norm_mu,z_norm_3b_mu,z_norm_4b_mu --setParameters r=0,tt_norm_e=$tt_e,z_norm_3b_e=$v_3b_e,z_norm_4b_e=$v_4b_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$v_3b_mu,z_norm_4b_mu=$v_4b_mu
+combine -M GoodnessOfFit -d workspace.root --algo=saturated --setParametersForFit mask_ee_A_SR_3b=1,mask_ee_A_SR_4b=1,mask_mumu_A_SR_3b=1,mask_mumu_A_SR_4b=1 --setParametersForEval mask_ee_A_SR_3b=0,mask_ee_A_SR_4b=0,mask_mumu_A_SR_3b=0,mask_mumu_A_SR_4b=0 --freezeParameters r,tt_norm_e,z_norm_3b_e,z_norm_4b_e,tt_norm_mu,z_norm_3b_mu,z_norm_4b_mu --setParameters r=0,mask_ee_A_SR_3b=1,mask_ee_A_SR_4b=1,mask_mumu_A_SR_3b=1,mask_mumu_A_SR_4b=1,tt_norm_e=$tt_e,z_norm_3b_e=$v_3b_e,z_norm_4b_e=$v_4b_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$v_3b_mu,z_norm_4b_mu=$v_4b_mu -t 100 --toysFrequentist # -s -1
+
+######## WH #########
+#tt_e=`cat simfit_m60_e.txt | grep 'tt_norm_e' | awk '{print $4;}'`;
+#tt_mu=`cat simfit_m60_mu.txt | grep 'tt_norm_mu' | awk '{print $4;}'`;
+#v_e=`cat simfit_m60_e.txt | grep 'w_norm_e' | awk '{print $4;}'`;
+#v_mu=`cat simfit_m60_mu.txt | grep 'w_norm_mu' | awk '{print $4;}'`;
+
+#combine -M GoodnessOfFit -d workspace.root --algo=saturated --setParametersForFit mask_e_A_SR_3b=1,mask_e_A_SR_4b=1,mask_mu_A_SR_3b=1,mask_mu_A_SR_4b=1 --setParametersForEval mask_e_A_SR_3b=0,mask_e_A_SR_4b=0,mask_mu_A_SR_3b=0,mask_mu_A_SR_4b=0 --freezeParameters r,tt_norm_e,w_norm_e,tt_norm_mu,w_norm_mu --setParameters r=0,tt_norm_e=$tt_e,w_norm_e=$v_e,tt_norm_mu=$tt_mu,w_norm_mu=$v_mu
+#combine -M GoodnessOfFit -d workspace.root --algo=saturated --setParametersForFit mask_e_A_SR_3b=1,mask_e_A_SR_4b=1,mask_mu_A_SR_3b=1,mask_mu_A_SR_4b=1 --setParametersForEval mask_e_A_SR_3b=0,mask_e_A_SR_4b=0,mask_mu_A_SR_3b=0,mask_mu_A_SR_4b=0 --freezeParameters r,tt_norm_e,w_norm_e,tt_norm_mu,w_norm_mu --setParameters r=0,mask_e_A_SR_3b=1,mask_e_A_SR_4b=1,mask_mu_A_SR_3b=1,mask_mu_A_SR_4b=1,tt_norm_e=$tt_e,w_norm_e=$v_e,tt_norm_mu=$tt_mu,w_norm_mu=$v_mu -t 100 --toysFrequentist #-s -1
+
+

--- a/test/haa4b/computeLimit/GOF/plotGOF.py
+++ b/test/haa4b/computeLimit/GOF/plotGOF.py
@@ -1,0 +1,105 @@
+import ROOT as rt
+import CMS_lumi, tdrstyle
+import array
+import os
+import sys
+
+from ROOT import gROOT, gBenchmark, gRandom, gSystem, Double
+
+
+#set the tdr style
+tdrstyle.setTDRStyle()
+rt.gStyle.SetOptStat(11111)
+#change the CMS_lumi variables (see CMS_lumi.py)
+CMS_lumi.lumi_7TeV = "4.8 fb^{-1}"
+CMS_lumi.lumi_8TeV = "18.3 fb^{-1}"
+CMS_lumi.writeExtraText = 1
+CMS_lumi.extraText = "Preliminary"
+CMS_lumi.lumi_sqrtS = "" #"13 TeV" # used with iPeriod = 0, e.g. for simulation-only plots (default is an empty string)
+
+iPos = 11
+if( iPos==0 ): CMS_lumi.relPosX = 0.12
+
+H_ref = 700; 
+W_ref = 700; 
+W = W_ref
+H  = H_ref
+
+# 
+# Simple example of macro: plot with CMS name and lumi text
+#  (this script does not pretend to work in all configurations)
+# iPeriod = 1*(0/1 7 TeV) + 2*(0/1 8 TeV)  + 4*(0/1 13 TeV) 
+# For instance: 
+#               iPeriod = 3 means: 7 TeV + 8 TeV
+#               iPeriod = 7 means: 7 TeV + 8 TeV + 13 TeV 
+#               iPeriod = 0 means: free form (uses lumi_sqrtS)
+# Initiated by: Gautier Hamel de Monchenault (Saclay)
+# Translated in Python by: Joshua Hardenbrook (Princeton)
+# Updated by:   Dinko Ferencek (Rutgers)
+#
+
+iPeriod = 0
+
+# references for T, B, L, R
+T = 0.08*H_ref
+B = 0.12*H_ref 
+L = 0.08*W_ref
+R = 0.12*W_ref
+
+canvas = rt.TCanvas("c2","c2",50,50,W,H)
+canvas.SetFillColor(0)
+canvas.SetBorderMode(0)
+canvas.SetFrameFillStyle(0)
+canvas.SetFrameBorderMode(0)
+canvas.SetLeftMargin( L/W )
+canvas.SetRightMargin( R/W )
+#canvas.SetTopMargin( T/H )
+#canvas.SetBottomMargin( B/H )
+canvas.SetTickx(0)
+canvas.SetTicky(0)
+
+# configure your card directory below after running ./goodnessfit.sh
+directory = "/afs/cern.ch/work/y/yuanc/Analysis/H2a4b/CMSSW_10_2_13/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/JOBS/SB13TeV_SM_Zh_backup/test/out_60_4b"
+datafname = "higgsCombineTest.GoodnessOfFit.mH120.root"
+toyfname = "higgsCombineTest.GoodnessOfFit.mH120.123456.root"
+
+dataf = rt.TFile.Open(os.path.join(directory, datafname))
+datatree = dataf.limit
+toyf = rt.TFile.Open(os.path.join(directory, toyfname))
+toytree = toyf.limit
+
+toytree.Draw("limit>>toy", "limit>=0","")
+#toytree.Draw("limit>>toy({},0,{})".format(100,700), "limit>=0","")
+hist = rt.gDirectory.Get("toy")
+ymax = hist.GetMaximum()
+hist.GetYaxis().SetRangeUser(0, ymax*1.2)
+
+for iev in datatree:
+  tobs = iev.limit
+if(tobs>=hist.GetXaxis().GetXmax()):
+  print("tobs: {}, max on Xaxis:{}".format(tobs, hist.GetXaxis().GetXmax()))
+  toytree.Draw("limit>>toy({},0,{})".format(100,int(tobs*1.2)), "limit>=0","")
+  hist = rt.gDirectory.Get("toy")
+  ymax = hist.GetMaximum()
+  hist.GetYaxis().SetRangeUser(0, ymax*1.2)
+  #hist.GetXaxis().SetRangeUser(0, 1000)
+line = rt.TLine(tobs, 0, tobs, ymax)
+line.SetLineColor(rt.kRed)
+line.SetLineWidth(3)
+line.Draw("same")
+
+
+#draw the lumi text on the canvas
+CMS_lumi.CMS_lumi(canvas, iPeriod, iPos)
+
+
+canvas.cd()
+canvas.Update()
+#canvas.SetLogx(True)
+canvas.RedrawAxis()
+
+canvas.SaveAs("GOF.pdf")
+
+canvas.Update()
+
+raw_input("Press Enter to end")

--- a/test/haa4b/computeLimit/GOF/tdrstyle.py
+++ b/test/haa4b/computeLimit/GOF/tdrstyle.py
@@ -1,0 +1,152 @@
+import ROOT as rt
+
+def tdrGrid( gridOn):
+  tdrStyle.SetPadGridX(gridOn)
+  tdrStyle.SetPadGridY(gridOn)
+
+#fixOverlay: Redraws the axis
+def fixOverlay(): gPad.RedrawAxis()
+
+def setTDRStyle():
+  tdrStyle =  rt.TStyle("tdrStyle","Style for P-TDR")
+
+   #for the canvas:
+  tdrStyle.SetCanvasBorderMode(0)
+  tdrStyle.SetCanvasColor(rt.kWhite)
+  tdrStyle.SetCanvasDefH(600) #Height of canvas
+  tdrStyle.SetCanvasDefW(600) #Width of canvas
+  tdrStyle.SetCanvasDefX(0)   #POsition on screen
+  tdrStyle.SetCanvasDefY(0)
+
+
+  tdrStyle.SetPadBorderMode(0)
+  #tdrStyle.SetPadBorderSize(Width_t size = 1)
+  tdrStyle.SetPadColor(rt.kWhite)
+  tdrStyle.SetPadGridX(False)
+  tdrStyle.SetPadGridY(False)
+  tdrStyle.SetGridColor(0)
+  tdrStyle.SetGridStyle(3)
+  tdrStyle.SetGridWidth(1)
+
+#For the frame:
+  tdrStyle.SetFrameBorderMode(0)
+  tdrStyle.SetFrameBorderSize(1)
+  tdrStyle.SetFrameFillColor(0)
+  tdrStyle.SetFrameFillStyle(0)
+  tdrStyle.SetFrameLineColor(1)
+  tdrStyle.SetFrameLineStyle(1)
+  tdrStyle.SetFrameLineWidth(1)
+  
+#For the histo:
+  #tdrStyle.SetHistFillColor(1)
+  #tdrStyle.SetHistFillStyle(0)
+  tdrStyle.SetHistLineColor(1)
+  tdrStyle.SetHistLineStyle(0)
+  tdrStyle.SetHistLineWidth(1)
+  #tdrStyle.SetLegoInnerR(Float_t rad = 0.5)
+  #tdrStyle.SetNumberContours(Int_t number = 20)
+
+  tdrStyle.SetEndErrorSize(2)
+  #tdrStyle.SetErrorMarker(20)
+  #tdrStyle.SetErrorX(0.)
+  
+  tdrStyle.SetMarkerStyle(20)
+  
+#For the fit/function:
+  tdrStyle.SetOptFit(1)
+  tdrStyle.SetFitFormat("5.4g")
+  tdrStyle.SetFuncColor(2)
+  tdrStyle.SetFuncStyle(1)
+  tdrStyle.SetFuncWidth(1)
+
+#For the date:
+  tdrStyle.SetOptDate(0)
+  # tdrStyle.SetDateX(Float_t x = 0.01)
+  # tdrStyle.SetDateY(Float_t y = 0.01)
+
+# For the statistics box:
+  tdrStyle.SetOptFile(0)
+  tdrStyle.SetOptStat(0) # To display the mean and RMS:   SetOptStat("mr")
+  tdrStyle.SetStatColor(rt.kWhite)
+  tdrStyle.SetStatFont(42)
+  tdrStyle.SetStatFontSize(0.025)
+  tdrStyle.SetStatTextColor(1)
+  tdrStyle.SetStatFormat("6.4g")
+  tdrStyle.SetStatBorderSize(1)
+  tdrStyle.SetStatH(0.1)
+  tdrStyle.SetStatW(0.15)
+  # tdrStyle.SetStatStyle(Style_t style = 1001)
+  # tdrStyle.SetStatX(Float_t x = 0)
+  # tdrStyle.SetStatY(Float_t y = 0)
+
+# Margins:
+  tdrStyle.SetPadTopMargin(0.05)
+  tdrStyle.SetPadBottomMargin(0.13)
+  tdrStyle.SetPadLeftMargin(0.16)
+  tdrStyle.SetPadRightMargin(0.02)
+
+# For the Global title:
+
+  tdrStyle.SetOptTitle(0)
+  tdrStyle.SetTitleFont(42)
+  tdrStyle.SetTitleColor(1)
+  tdrStyle.SetTitleTextColor(1)
+  tdrStyle.SetTitleFillColor(10)
+  tdrStyle.SetTitleFontSize(0.05)
+  # tdrStyle.SetTitleH(0) # Set the height of the title box
+  # tdrStyle.SetTitleW(0) # Set the width of the title box
+  # tdrStyle.SetTitleX(0) # Set the position of the title box
+  # tdrStyle.SetTitleY(0.985) # Set the position of the title box
+  # tdrStyle.SetTitleStyle(Style_t style = 1001)
+  # tdrStyle.SetTitleBorderSize(2)
+
+# For the axis titles:
+
+  tdrStyle.SetTitleColor(1, "XYZ")
+  tdrStyle.SetTitleFont(42, "XYZ")
+  tdrStyle.SetTitleSize(0.05, "XYZ")
+  # tdrStyle.SetTitleXSize(Float_t size = 0.02) # Another way to set the size?
+  # tdrStyle.SetTitleYSize(Float_t size = 0.02)
+  tdrStyle.SetTitleXOffset(0.9)
+  tdrStyle.SetTitleYOffset(1.25)
+  # tdrStyle.SetTitleOffset(1.1, "Y") # Another way to set the Offset
+
+# For the axis labels:
+
+  tdrStyle.SetLabelColor(1, "XYZ")
+  tdrStyle.SetLabelFont(42, "XYZ")
+  tdrStyle.SetLabelOffset(0.007, "XYZ")
+  tdrStyle.SetLabelSize(0.035, "XYZ")
+
+# For the axis:
+
+  tdrStyle.SetAxisColor(1, "XYZ")
+  tdrStyle.SetStripDecimals(True)
+  tdrStyle.SetTickLength(0.03, "XYZ")
+  tdrStyle.SetNdivisions(510, "XYZ")
+  tdrStyle.SetPadTickX(1)  # To get tick marks on the opposite side of the frame
+  tdrStyle.SetPadTickY(1)
+
+# Change for log plots:
+  tdrStyle.SetOptLogx(0)
+  tdrStyle.SetOptLogy(0)
+  tdrStyle.SetOptLogz(0)
+
+# Postscript options:
+  tdrStyle.SetPaperSize(20.,20.)
+  # tdrStyle.SetLineScalePS(Float_t scale = 3)
+  # tdrStyle.SetLineStyleString(Int_t i, const char* text)
+  # tdrStyle.SetHeaderPS(const char* header)
+  # tdrStyle.SetTitlePS(const char* pstitle)
+
+  # tdrStyle.SetBarOffset(Float_t baroff = 0.5)
+  # tdrStyle.SetBarWidth(Float_t barwidth = 0.5)
+  # tdrStyle.SetPaintTextFormat(const char* format = "g")
+  # tdrStyle.SetPalette(Int_t ncolors = 0, Int_t* colors = 0)
+  # tdrStyle.SetTimeOffset(Double_t toffset)
+  # tdrStyle.SetHistMinimumZero(kTRUE)
+
+  tdrStyle.SetHatchesLineWidth(5)
+  tdrStyle.SetHatchesSpacing(0.05)
+
+  tdrStyle.cd()

--- a/test/haa4b/computeLimit/README
+++ b/test/haa4b/computeLimit/README
@@ -10,9 +10,8 @@ where :
 ## Run the limit scan in all A mass points
 1. configure the input variable jsonPath, inUrl_wh and inUrl_zh in the oprimize_haa.py
 2. submit jobs to the batch mode:
-> python optimize_haa.py -p 4.0 -t
+> python optimize_haa.py -p 4.0
   , where '4.0' is to run Wh channel, use 4.1 to run Zh channel and 5.0 to run Wh+Zh combined
-  '-t' should be included to turn on the option: autoMCstats
 3. when jobs finished, produce limit plots:
 > python optimize_haa.py -p 6.0
   , where '6.0' is to produce plots for Wh channel, use 6.1 for Zh channel and 6.2 for Wh+Zh combined 

--- a/test/haa4b/computeLimit/optimize_haa.py
+++ b/test/haa4b/computeLimit/optimize_haa.py
@@ -24,30 +24,24 @@ CMSSW_BASE=os.environ.get('CMSSW_BASE')
 CWD=os.getcwd()
 phase=-1
 
-autoMCstats = True
+autoMCstats = False
 thredMCstat = 0.001
+BackExtrapol = " --BackExtrapol"
 ###################################################
 ##   VALUES TO BE EDITED BY THE USE ARE BELLOW   ##
 ###################################################
 
 MODELS=["SM"] 
 based_key="haa_mcbased" #mcbased_" #to run limits on MC use: haa_mcbased_, to use data driven obj use: haa_datadriven_
-jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2016_mergeSmallBckg.json'
-#jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2017_mergeSmallBckg.json'
-#jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2018_mergeSmallBckg.json'
+jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2016.json'
+#jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2017.json'
+#jsonPath='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/samples2018.json'
 
-inUrl='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_WH_forLimits.root'
-#inUrl='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_Wh_2017_forLimits.root'
-#inUrl='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2018_WH_forLimits.root'
+#inUrl='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_WH_topSF_VJmerge_forLimits.root'
+inUrl='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_ZH_SysforLimits.root'
 
-#inUrl_wh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_combine_WH_forLimits.root'
-#inUrl_zh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_combine_ZH_forLimits.root'
 inUrl_wh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_WH_forLimits.root'
-inUrl_zh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_ZH_forLimits.root'
-#inUrl_wh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_Wh_2017_forLimits.root'
-#inUrl_zh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_Zh_2017_forLimits.root'
-#inUrl_wh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2018_WH_forLimits.root'
-#inUrl_zh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2018_ZH_forLimits.root'
+inUrl_zh='$CMSSW_BASE/src/UserCode/bsmhiggs_fwk/test/haa4b/plotter_2016_ZH_SysforLimits.root'
 
 BESTDISCOVERYOPTIM=True #Set to True for best discovery optimization, Set to False for best limit optimization
 ASYMTOTICLIMIT=True #Set to True to compute asymptotic limits (faster) instead of toy based hybrid-new limits
@@ -57,8 +51,8 @@ BINS = ["3b","4b","3b,4b"] # list individual analysis bins to consider as well a
 MASS = [12, 15, 20, 25, 30, 40, 50, 60]
 SUBMASS = [12, 15, 20, 25, 30, 40, 50, 60]
 
-#LandSArgCommonOptions=" --dropBckgBelow 0.01 --statBinByBin 0.001 " #--BackExtrapol " #--statBinByBin 0.00001 "
-LandSArgCommonOptions=" --dropBckgBelow 0.01 " # --statBinByBin 0.001 " #--BackExtrapol " #--statBinByBin 0.00001 "
+LandSArgCommonOptions=" --dropBckgBelow 0.01 --statBinByBin 0.001 " #--BackExtrapol " #--statBinByBin 0.00001 "
+#LandSArgCommonOptions=" --dropBckgBelow 0.01 " # --statBinByBin 0.001 " #--BackExtrapol " #--statBinByBin 0.00001 "
 #LandSArgCommonOptions="  --BackExtrapol --statBinByBin 0.00001 --dropBckgBelow 0.00001 --blind"
 
 for model in MODELS:
@@ -135,7 +129,7 @@ def findSideMassPoint(mass):
 
 #######################
 print("autoMCstats = {}".format(autoMCstats))
-
+print("BackExtrapol = {}".format(BackExtrapol))
 #Loop over all configurations
 iConf = -1
 cp = 0
@@ -402,10 +396,7 @@ for signalSuffix in signalSuffixVec :
 
            cardsdir=DataCardsDir+"/"+('%04.0f' % float(m));
            SCRIPT.writelines('mkdir -p out_{};\ncd out_{};\n'.format(m,m)) #--blind instead of --simfit
-#           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --blind --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
-           #SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --modeDD --subFake" + " " + LandSArg + cutStr  +" ;\n")
-           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --modeDD --shape --subFake " + LandSArg + cutStr  +" ;\n")
-#           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs +  " " + LandSArg + cutStr  +" ;\n")
+           SCRIPT.writelines("computeLimit --m " + str(m) + BackExtrapol + " --in " + inUrl + " " + "--syst --simfit --index 1 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --modeDD --shape --subFake " + LandSArg + cutStr  +" ;\n")
            SCRIPT.writelines("sh combineCards_wh.sh;\n"); 
 
 	   if autoMCstats:
@@ -443,12 +434,9 @@ for signalSuffix in signalSuffixVec :
            if(ASYMTOTICLIMIT==True):
               SCRIPT.writelines("tt_e=`cat simfit_m"+ str(m) +"_e.txt | grep 'tt_norm_e' | awk '{print $4;}'`;\n")
               SCRIPT.writelines("tt_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'tt_norm_mu' | awk '{print $4;}'`;\n")
-              SCRIPT.writelines("v_e=`cat simfit_m"+ str(m) +"_e.txt | grep 'w_norm_e' | awk '{print $4;}'`;\n") 
-#              SCRIPT.writelines("v_4b_e=`cat simfit_m"+ str(m) +".txt | grep 'w_norm_4b_e' | awk '{print $4;}'`;\n")
-              SCRIPT.writelines("v_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'w_norm_mu' | awk '{print $4;}'`;\n")
-#              SCRIPT.writelines("v_4b_mu=`cat simfit_m"+ str(m) +".txt | grep 'w_norm_4b_mu' | awk '{print $4;}'`;\n")
-#              SCRIPT.writelines("combine -M Asymptotic -m " +  str(m) + " workspace.root --run blind -v 3 >  COMB.log;\n") 
-              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --setParameters tt_norm_e=$tt_e,w_norm_e=$v_e,tt_norm_mu=$tt_mu,w_norm_mu=$v_mu > COMB.log;\n")  
+	      SCRIPT.writelines("v_e=`cat simfit_m"+ str(m) +"_e.txt | grep 'w_norm_e' | awk '{print $4;}'`;\n")
+	      SCRIPT.writelines("v_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'w_norm_mu' | awk '{print $4;}'`;\n")
+	      SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --freezeParameters tt_norm_e,w_norm_e,tt_norm_mu,w_norm_mu --setParameters tt_norm_e=$tt_e,w_norm_e=$v_e,tt_norm_mu=$tt_mu,w_norm_mu=$v_mu > COMB.log;\n")
 
            ### THIS is for toy (hybridNew) fit
            else:
@@ -548,7 +536,7 @@ for signalSuffix in signalSuffixVec :
 
            cardsdir=DataCardsDir+"/"+('%04.0f' % float(m));
            SCRIPT.writelines('mkdir -p out_{};\ncd out_{};\n'.format(m,m)) #--blind instead of --simfit
-           SCRIPT.writelines("computeLimit --runZh --m " + str(m) + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
+           SCRIPT.writelines("computeLimit --runZh --m " + str(m) + BackExtrapol + " --in " + inUrl + " " + "--syst --simfit --shape --index 1 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
            SCRIPT.writelines("sh combineCards_zh.sh;\n"); 
            SCRIPT.writelines("sed -i '/rateParam emu/d' card_combined_zh.dat\n"); 
 
@@ -556,7 +544,7 @@ for signalSuffix in signalSuffixVec :
 	      SCRIPT.writelines("\nsed -i '$a*	   autoMCStats	   {}' card_e_zh.dat".format(thredMCstat))
            SCRIPT.writelines("\ntext2workspace.py card_e_zh.dat -o workspace_e.root --PO verbose --channel-masks  --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n")  
            SCRIPT.writelines("combine -M Significance --signif --pvalue -m " +  str(m) + " workspace_e.root > COMB.log;\n")
-           SCRIPT.writelines("combine -M FitDiagnostics workspace_e.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ee_A_SR_3b=1,mask_ee_A_SR_4b=1 > log_e.txt \n") 
+           SCRIPT.writelines("combine -M FitDiagnostics workspace_e.root -m " +  str(m) + " -v 3 --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ee_A_SR_3b=1,mask_ee_A_SR_4b=1 > log_e.txt \n") 
            SCRIPT.writelines("python " + CMSSW_BASE + "/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/print.py -u fitDiagnostics.root > simfit_m"+ str(m)+"_e.txt \n")
 	   SCRIPT.writelines("python " + CMSSW_BASE + "/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -A -a fitDiagnostics.root -g Nuisance_CrossCheck.root >> simfit_m"+ str(m) +"_e.txt\n")
 	   SCRIPT.writelines("mv fitDiagnostics.root fitDiagnostics_e.root\n")
@@ -565,10 +553,11 @@ for signalSuffix in signalSuffixVec :
 	      SCRIPT.writelines("\nsed -i '$a*	   autoMCStats	   {}' card_mu_zh.dat".format(thredMCstat))
            SCRIPT.writelines("\ntext2workspace.py card_mu_zh.dat -o workspace_mu.root --PO verbose --channel-masks  --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n")  
            SCRIPT.writelines("combine -M Significance --signif --pvalue -m " +  str(m) + " workspace_mu.root > COMB.log;\n")
-           SCRIPT.writelines("combine -M FitDiagnostics workspace_mu.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-50 --rMax=50 --stepSize=0.05 --robustFit 1 --setParameters mask_mumu_A_SR_3b=1,mask_mumu_A_SR_4b=1 > log_mu.txt \n") 
+           SCRIPT.writelines("combine -M FitDiagnostics workspace_mu.root -m " +  str(m) + " -v 3 --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-50 --rMax=50 --stepSize=0.05 --robustFit 1 --setParameters mask_mumu_A_SR_3b=1,mask_mumu_A_SR_4b=1 > log_mu.txt \n") 
            SCRIPT.writelines("python " + CMSSW_BASE + "/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/print.py -u fitDiagnostics.root > simfit_m"+ str(m)+"_mu.txt \n")
 	   SCRIPT.writelines("python " + CMSSW_BASE + "/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -A -a fitDiagnostics.root -g Nuisance_CrossCheck.root >> simfit_m"+ str(m) +"_mu.txt\n")
 	   SCRIPT.writelines("mv fitDiagnostics.root fitDiagnostics_mu.root\n")
+
 
 	   if autoMCstats:
 	      SCRIPT.writelines("\nsed -i '$a*	   autoMCStats	   {}' card_combined_zh.dat".format(thredMCstat))
@@ -582,7 +571,8 @@ for signalSuffix in signalSuffixVec :
               SCRIPT.writelines("v_4b_e=`cat simfit_m"+ str(m) +"_e.txt | grep 'z_norm_4b_e' | awk '{print $4;}'`;\n")
               SCRIPT.writelines("v_3b_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'z_norm_3b_mu' | awk '{print $4;}'`;\n")
               SCRIPT.writelines("v_4b_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'z_norm_4b_mu' | awk '{print $4;}'`;\n")
-              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --setParameters tt_norm_e=$tt_e,z_norm_3b_e=$v_3b_e,z_norm_4b_e=$v_4b_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$v_3b_mu,z_norm_4b_mu=$v_4b_mu > COMB.log;\n")  
+              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --freezeParameters tt_norm_e,z_norm_3b_e,z_norm_4b_e,tt_norm_mu,z_norm_3b_mu,z_norm_4b_mu --setParameters tt_norm_e=$tt_e,z_norm_3b_e=$v_3b_e,z_norm_4b_e=$v_4b_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$v_3b_mu,z_norm_4b_mu=$v_4b_mu > COMB.log;\n")  
+#              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --setParameters tt_norm_e=$tt_e,zb_norm_e=$v_1b_e,z2b_norm_e=$v_2b_e,tt_norm_mu=$tt_mu,zb_norm_mu=$v_1b_mu,z2b_norm_mu=$v_2b_mu > COMB.log;\n")  
 
            else:
               SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root > COMB.log;\n") #first run assymptotic limit to get quickly the range of interest
@@ -683,8 +673,8 @@ for signalSuffix in signalSuffixVec :
 
            cardsdir=DataCardsDir+"/"+('%04.0f' % float(m));
            SCRIPT.writelines('mkdir -p out_{};\ncd out_{};\n'.format(m,m)) #--blind instead of --simfit
-           SCRIPT.writelines("computeLimit --m " + str(m) + " --in " + inUrl_wh + " " + "--syst --simfit --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --modeDD --shape --subFake " + LandSArg + cutStr  +" ;\n")
-           SCRIPT.writelines("computeLimit --runZh --m " + str(m) + " --in " + inUrl_zh + " " + "--syst --simfit --shape --index 1 --rebin 6 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
+           SCRIPT.writelines("computeLimit --m " + str(m) + BackExtrapol + " --in " + inUrl_wh + " " + "--syst --simfit --index 1 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " --modeDD --shape --subFake " + LandSArg + cutStr  +" ;\n")
+           SCRIPT.writelines("computeLimit --runZh --m " + str(m) + BackExtrapol + " --in " + inUrl_zh + " " + "--syst --simfit --shape --index 1 --bins " + BIN[iConf] + " --json " + jsonUrl + " " + SideMassesArgs + " " + LandSArg + cutStr  +" ;\n")
            SCRIPT.writelines("sh combineCards_wh.sh;\n"); 
            SCRIPT.writelines("sh combineCards_zh.sh;\n"); 
            SCRIPT.writelines("combineCards.py card_e_wh.dat card_e_zh.dat > card_e.dat\n"); 
@@ -696,7 +686,7 @@ for signalSuffix in signalSuffixVec :
 	      SCRIPT.writelines("\nsed -i '$a*	   autoMCStats	   {}' card_e.dat".format(thredMCstat))
            SCRIPT.writelines("\ntext2workspace.py card_e.dat -o workspace_e.root --PO verbose --channel-masks  --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n")  
            SCRIPT.writelines("combine -M Significance --signif --pvalue -m " +  str(m) + " workspace_e.root > COMB_e.log;\n")
-           SCRIPT.writelines("combine -M FitDiagnostics workspace_e.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ch2_ee_A_SR_3b=1,mask_ch2_ee_A_SR_4b=1,mask_ch1_e_A_SR_3b=1,mask_ch1_e_A_SR_4b=1 > log_e.txt \n") 
+           SCRIPT.writelines("combine -M FitDiagnostics workspace_e.root -m " +  str(m) + " -v 3 --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ch2_ee_A_SR_3b=1,mask_ch2_ee_A_SR_4b=1,mask_ch1_e_A_SR_3b=1,mask_ch1_e_A_SR_4b=1 > log_e.txt \n") 
            SCRIPT.writelines("python " + CMSSW_BASE + "/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/print.py -u fitDiagnostics.root > simfit_m"+ str(m)+"_e.txt \n")
 	   SCRIPT.writelines("python " + CMSSW_BASE + "/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -A -a fitDiagnostics.root -g Nuisance_CrossCheck.root >> simfit_m"+ str(m) +"_e.txt\n")
 	   SCRIPT.writelines("mv fitDiagnostics.root fitDiagnostics_e.root\n")
@@ -705,7 +695,7 @@ for signalSuffix in signalSuffixVec :
 	      SCRIPT.writelines("\nsed -i '$a*	   autoMCStats	   {}' card_mu.dat".format(thredMCstat))
            SCRIPT.writelines("\ntext2workspace.py card_mu.dat -o workspace_mu.root --PO verbose --channel-masks  --PO \'ishaa\' --PO m=\'" + str(m) + "\'  \n")  
            SCRIPT.writelines("combine -M Significance --signif --pvalue -m " +  str(m) + " workspace_mu.root > COMB_mu.log;\n")
-           SCRIPT.writelines("combine -M FitDiagnostics workspace_mu.root -m " +  str(m) + " -v 3  --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ch2_mumu_A_SR_3b=1,mask_ch2_mumu_A_SR_4b=1,mask_ch1_mu_A_SR_3b=1,mask_ch1_mu_A_SR_4b=1 > log_mu.txt \n") 
+           SCRIPT.writelines("combine -M FitDiagnostics workspace_mu.root -m " +  str(m) + " -v 3 --plots --saveNormalizations --saveShapes --saveWithUncertainties --saveNLL  --rMin=-20 --rMax=20 --stepSize=0.05 --robustFit 1 --setParameters mask_ch2_mumu_A_SR_3b=1,mask_ch2_mumu_A_SR_4b=1,mask_ch1_mu_A_SR_3b=1,mask_ch1_mu_A_SR_4b=1 > log_mu.txt \n") 
            SCRIPT.writelines("python " + CMSSW_BASE + "/src/UserCode/bsmhiggs_fwk/test/haa4b/computeLimit/print.py -u fitDiagnostics.root > simfit_m"+ str(m)+"_mu.txt \n")
 	   SCRIPT.writelines("python " + CMSSW_BASE + "/src/HiggsAnalysis/CombinedLimit/test/diffNuisances.py -A -a fitDiagnostics.root -g Nuisance_CrossCheck.root >> simfit_m"+ str(m) +"_mu.txt\n")
 	   SCRIPT.writelines("mv fitDiagnostics.root fitDiagnostics_mu.root\n")
@@ -724,7 +714,7 @@ for signalSuffix in signalSuffixVec :
               SCRIPT.writelines("z_3b_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'z_norm_3b_mu' | awk '{print $4;}'`;\n")
               SCRIPT.writelines("z_4b_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'z_norm_4b_mu' | awk '{print $4;}'`;\n")
               SCRIPT.writelines("w_mu=`cat simfit_m"+ str(m) +"_mu.txt | grep 'w_norm_mu' | awk '{print $4;}'`;\n")
-              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --setParameters tt_norm_e=$tt_e,z_norm_3b_e=$z_3b_e,z_norm_4b_e=$z_4b_e,w_norm_e=$w_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$z_3b_mu,z_norm_4b_mu=$z_4b_mu,w_norm_mu=$w_mu > COMB.log;\n")  
+              SCRIPT.writelines("combine -M AsymptoticLimits -m " +  str(m) + " workspace.root -t -1 --freezeParameters tt_norm_e,z_norm_3b_e,z_norm_4b_e,w_norm_e,tt_norm_mu,z_norm_3b_mu,z_norm_4b_mu,w_norm_mu --setParameters tt_norm_e=$tt_e,z_norm_3b_e=$z_3b_e,z_norm_4b_e=$z_4b_e,w_norm_e=$w_e,tt_norm_mu=$tt_mu,z_norm_3b_mu=$z_3b_mu,z_norm_4b_mu=$z_4b_mu,w_norm_mu=$w_mu > COMB.log;\n")  
 
            else:
 	      print("Do not support this mode!!!")


### PR DESCRIPTION
1. Drop emu channels in Zh combined datacard;
2. Add a GOF folder under computeLimit to accommodate latest codes for GOF computing;
3. Update optimize_haa.py to switch to use statBinbyBin instead of autoMCstats, and freeze normalizations when computing limits.