### PR TITLE
Bug fix in JEC Uncertainty, include L2L3 residual Jec correction and lastest top reweighting in Zh

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -2925,8 +2925,8 @@ int main(int argc, char* argv[])
 		else if(tag_subcat.Contains("4b")) topptsf = exp(0.02629-0.00098*wsum.pt());
 	      }
 	      else if(runZH){ // Zh
-		if(tag_subcat.Contains("3b")) topptsf = exp(0.17631-0.00104*wsum.pt());
-		else if(tag_subcat.Contains("4b")) topptsf = exp(0.41001-0.00184*wsum.pt());
+		if(tag_subcat.Contains("3b")) topptsf = exp(0.02826-0.00102*wsum.pt());
+		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.04341-0.00067*wsum.pt());
 	      }
 	    }
 	    else if(is2017MC){
@@ -2935,8 +2935,8 @@ int main(int argc, char* argv[])
 		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.07055-0.00171*wsum.pt());
 	      }
 	      else if(runZH){ // Zh
-		if(tag_subcat.Contains("3b")) topptsf = exp(-0.36720+0.00076*wsum.pt());
-		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.18413-0.00008*wsum.pt());
+		if(tag_subcat.Contains("3b")) topptsf = exp(-0.10682-0.00098*wsum.pt());
+		else if(tag_subcat.Contains("4b")) topptsf = exp(0.03679-0.00143*wsum.pt());
 	      }
 	    }
 	    else if(is2018MC){
@@ -2945,8 +2945,8 @@ int main(int argc, char* argv[])
 		else if(tag_subcat.Contains("4b")) topptsf = exp(0.00503-0.00036*wsum.pt());
 	      }
 	      else if(runZH){ // Zh
-		if(tag_subcat.Contains("3b")) topptsf = exp(0.05378-0.00036*wsum.pt());
-		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.03831-0.00035*wsum.pt());
+		if(tag_subcat.Contains("3b")) topptsf = exp(-0.18502+0.00059*wsum.pt());
+		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.23199+0.00076*wsum.pt());
 	      }
 	    }
 //	    std::cout << tag_subcat << ", ptw " << wsum.pt() << ", sf: " << topptsf << std::endl;

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -2732,26 +2732,22 @@ int main(int argc, char* argv[])
 	
  	  if(isMC_DY && !dtag.Contains("amcNLO") && reweightDYZPt){
 	    double ptsf=1.0;
-	    if(zpt >= 35){
+//	    if(zpt >= 35){
 //	      if(GoodIdJets.size()==2) {ptsf = getSFfrom1DHist(zpt, zptSF_2j);}//{ptsf = (zpt<thred_2j) ? zfit_2j->Eval(zpt) :  getSFfrom1DHist(zpt, zptSF_2j);}// std::cout << "3j: " << zpt << ", sf: " << getSFfrom1DHist(zpt, zptSF_3j) << std::endl;}
 	      if(GoodIdJets.size()==3) {ptsf = getSFfrom1DHist(zpt, zptSF_3j);}//{ptsf = (zpt<thred_3j) ? zfit_3j->Eval(zpt) :  getSFfrom1DHist(zpt, zptSF_3j);}// std::cout << "4j: " << zpt << ", sf: " << getSFfrom1DHist(zpt, zptSF_4j) << std::endl;}
 	      else if(GoodIdJets.size()==4) {ptsf = getSFfrom1DHist(zpt, zptSF_4j);}//{ptsf = (zpt<thred_4j) ? zfit_4j->Eval(zpt) :  getSFfrom1DHist(zpt, zptSF_4j);}// std::cout << "4j: " << zpt << ", sf: " << getSFfrom1DHist(zpt, zptSF_4j) << std::endl;}
 	      else if(GoodIdJets.size()>=5) {ptsf = getSFfrom1DHist(zpt, zptSF_5j);}//{ptsf = (zpt<thred_5j) ? zfit_5j->Eval(zpt) :  getSFfrom1DHist(zpt, zptSF_5j);}// std::cout << "5j: " << zpt << ", sf: " << getSFfrom1DHist(zpt, zptSF_5j) << std::endl;}
-	    }
+//	    }
 //	    std::cout << GoodIdJets.size() << ", " << zpt << ", sf: " << ptsf << std::endl;
 	    weight *= ptsf;
 	  }
 	  if(ivar == 0 && isMC_DY ){
-	    //mon.fillHisto("jetsMulti","alljets",GoodIdJets.size(),1);
-	    mon.fillHisto("ptw","alljets",zpt,xsecWeight*genWeight); 
+	    mon.fillHisto("jetsMulti","alljets",GoodIdJets.size(),1);
 	    mon.fillHisto("ptw","alljets",zpt,weight); 
 	    mon.fillHisto("ptw_full","debug",zpt,1); 
-	    if(GoodIdJets.size()==3) {mon.fillHisto("ptw","3jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_3jets",zpt,xsecWeight*genWeight);}
-	    else if(GoodIdJets.size()==4) {mon.fillHisto("ptw","4jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_4jets",zpt,xsecWeight*genWeight);}
-	    else if(GoodIdJets.size()>=5) {mon.fillHisto("ptw","5+jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_5+jets",zpt,xsecWeight*genWeight);}
-	    //if(GoodIdJets.size()==3) {mon.fillHisto("ptw","3jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_3jets",zpt,weight);}
-	    //else if(GoodIdJets.size()==4) {mon.fillHisto("ptw","4jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_4jets",zpt,weight);}
-	    //else if(GoodIdJets.size()>=5) {mon.fillHisto("ptw","5+jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_5+jets",zpt,weight);}
+	    if(GoodIdJets.size()==3) {mon.fillHisto("ptw","3jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_3jets",zpt,weight);}
+	    else if(GoodIdJets.size()==4) {mon.fillHisto("ptw","4jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_4jets",zpt,weight);}
+	    else if(GoodIdJets.size()>=5) {mon.fillHisto("ptw","5+jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_5+jets",zpt,weight);}
 	}
 	  //	  if (!passMnBTag) continue; //at least 1 MediumWP b-tag if nBjets>0
 	  
@@ -2927,13 +2923,10 @@ int main(int argc, char* argv[])
 
 	  if(reweightTopPt && isMC_ttbar){
 	    double topptsf=1.0;
-	    if(is2016MC && mctruthmode==1){ // formula for 2016
+	    if(is2016MC){ // formula for 2016
 	      if(!runZH){ // Wh
-		if(tag_subcat.Contains("3b")) topptsf = exp(0.06117-0.00134*wsum.pt());
-		else if(tag_subcat.Contains("4b")) topptsf = exp(0.05567-0.00182*wsum.pt());
-		//if(tag_subcat.Contains("3b")) topptsf = exp(0.04182-0.00095*wsum.pt());
-		//else if(tag_subcat.Contains("4b")) topptsf = exp(0.02629-0.00098*wsum.pt());
-	        //std::cout << tag_subcat << ", ptw " << wsum.pt() << ", sf: " << topptsf << std::endl;
+		if(tag_subcat.Contains("3b")) topptsf = exp(0.04182-0.00095*wsum.pt());
+		else if(tag_subcat.Contains("4b")) topptsf = exp(0.02629-0.00098*wsum.pt());
 	      }
 	      else if(runZH){ // Zh
 		if(tag_subcat.Contains("3b")) topptsf = exp(0.02826-0.00102*wsum.pt());

--- a/interface/METUtils.h
+++ b/interface/METUtils.h
@@ -42,6 +42,7 @@ namespace METUtils {
 			   PhysicsObjectJetCollection& jets,
 			   PhysicsObjectLeptonCollection &leptons,       
 			   std::vector<PhysicsObjectJetCollection>& jetsVar, 
+			   std::vector< std::vector<double> >& variedJECSFs, 
 			   std::vector<JetCorrectionUncertainty*>& jecUnc,
 			   Int_t yearBits);
 

--- a/src/METUtils.cc
+++ b/src/METUtils.cc
@@ -292,7 +292,8 @@ PhysicsObject_Jet smearedJet(JME::JetResolutionScaleFactor& jer_sf, const Physic
 		      JME::JetResolutionScaleFactor& jer_sf,
 		      PhysicsObjectJetCollection& jets,
                       PhysicsObjectLeptonCollection& leptons,
-                       std::vector<PhysicsObjectJetCollection>& jetsVar,
+		      std::vector<PhysicsObjectJetCollection>& jetsVar,
+		      std::vector< std::vector<double> >& jecSFs,
  		      std::vector<JetCorrectionUncertainty*> &jecUnc,
 		      Int_t yearBits)
 		      //                      JetCorrectionUncertainty *jecUnc)
@@ -325,6 +326,7 @@ PhysicsObject_Jet smearedJet(JME::JetResolutionScaleFactor& jer_sf, const Physic
 
       for(size_t ivar=0; ivar<2; ivar++) { //ivar<sizeof(jesvars)/sizeof(int); ivar++) {
 	PhysicsObjectJetCollection newJets;
+	std::vector<double> jecSF;
 	LorentzVector jetDiff(0,0,0,0);
 	
 	for(size_t ijet=0; ijet<jets.size(); ijet++) {
@@ -339,7 +341,9 @@ PhysicsObject_Jet smearedJet(JME::JetResolutionScaleFactor& jer_sf, const Physic
 	    unc->setJetEta(jets[ijet].eta());
 	    unc->setJetPt(jets[ijet].pt());
 	    //jetScale = 1.0 + fabs(unc->getUncertainty(varSign)); 
-	    jetScale = 1.0 + varSign*fabs(unc->getUncertainty(true));
+	    //jetScale = 1.0 + varSign*fabs(unc->getUncertainty(true));
+	    // https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetCorUncertainties
+	    jetScale = 1.0 + varSign*unc->getUncertainty(true);
 	  } catch(std::exception &e) {
 	    cout << "[METUtils::computeVariation]" << e.what() << ijet << " " << jets[ijet].pt() << endl;
 	  }
@@ -348,12 +352,13 @@ PhysicsObject_Jet smearedJet(JME::JetResolutionScaleFactor& jer_sf, const Physic
 	  iScaleJet *= jetScale;
 	  jetDiff += (iScaleJet-jets[ijet]);
 	  newJets.push_back(iScaleJet);
-	  
+	  jecSF.push_back(jetScale);
 	  // up OR down end
 	} // ijet loop 
 
 	//add new jets (if some change has occured)
 	jetsVar.push_back(newJets);
+	jecSFs.push_back(jecSF);
       
       } // loop on up and down
     } //JES nsrc sources end

--- a/test/fullAnalysis_cfg.py.templ
+++ b/test/fullAnalysis_cfg.py.templ
@@ -34,10 +34,11 @@ bTagDiscriminators = [
 ]
 from PhysicsTools.PatAlgos.tools.jetTools import *
 ## Update the slimmedJets in miniAOD: corrections from the chosen Global Tag are applied and the b-tag discriminators are re-evaluated
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#CorrPatJets
 updateJetCollection(
     process,
     jetSource = cms.InputTag('slimmedJets'),
-    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'), # Update: Safe to always add 'L2L3Residual' as MC contains dummy L2L3Residual corrections (always set to 1)
     btagDiscriminators = bTagDiscriminators
 )
 

--- a/test/haa4b/runlocal_test.py
+++ b/test/haa4b/runlocal_test.py
@@ -36,7 +36,7 @@ from PhysicsTools.PatAlgos.tools.jetTools import *
 updateJetCollection(
     process,
     jetSource = cms.InputTag('slimmedJets'),
-    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual']), 'None'), # Update: Safe to always add 'L2L3Residual' as MC contains dummy L2L3Residual corrections (always set to 1)
     btagDiscriminators = bTagDiscriminators
 )
 

--- a/test/runNtplAnalysis_cfg.py.templ
+++ b/test/runNtplAnalysis_cfg.py.templ
@@ -44,13 +44,14 @@ runProcess = cms.PSet(
     muscleDir =  cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/jec/'),
     jecDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/jec/25ns/'),
     zptDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/weights'),
+    topptDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/weights'),
     btagDir = cms.string("@btagDir"),
     usemetNoHF = cms.bool(@usemetNoHF),	
     useDeepCSV = cms.bool(@useDeepCSV),
     runQCD = cms.bool(@runQCD), 
     debug = cms.bool(False),
-    evStart = cms.int32(0),
-    evEnd = cms.int32(-1)
+    evStart = cms.int32(@evStart),
+    evEnd = cms.int32(@evEnd)
 )
 
 try:

--- a/test/runNtplAnalysis_cfg.py.templ
+++ b/test/runNtplAnalysis_cfg.py.templ
@@ -44,14 +44,13 @@ runProcess = cms.PSet(
     muscleDir =  cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/jec/'),
     jecDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/jec/25ns/'),
     zptDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/weights'),
-    topptDir = cms.string('${CMSSW_BASE}/src/UserCode/bsmhiggs_fwk/data/weights'),
     btagDir = cms.string("@btagDir"),
     usemetNoHF = cms.bool(@usemetNoHF),	
     useDeepCSV = cms.bool(@useDeepCSV),
     runQCD = cms.bool(@runQCD), 
     debug = cms.bool(False),
-    evStart = cms.int32(@evStart),
-    evEnd = cms.int32(@evEnd)
+    evStart = cms.int32(0),
+    evEnd = cms.int32(-1)
 )
 
 try:


### PR DESCRIPTION
1. Fix the bug when accessing the 'up' and 'down' JEC uncertainties, and add debugging histograms showing jec_sf vs bdt;
2. Include 'L2L3Residual' Jet Correction in 2016 data Ntuplizer;
3. Update the latest top reweighting numbers in Zh channel.