### PR TITLE
Add 2016 Legacy Json file

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -2743,11 +2743,11 @@ int main(int argc, char* argv[])
 	  }
 	  if(ivar == 0 && isMC_DY ){
 	    mon.fillHisto("jetsMulti","alljets",GoodIdJets.size(),1);
-	    mon.fillHisto("ptw","alljets",zpt,weight); 
 	    mon.fillHisto("ptw_full","debug",zpt,1); 
-	    if(GoodIdJets.size()==3) {mon.fillHisto("ptw","3jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_3jets",zpt,weight);}
-	    else if(GoodIdJets.size()==4) {mon.fillHisto("ptw","4jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_4jets",zpt,weight);}
-	    else if(GoodIdJets.size()>=5) {mon.fillHisto("ptw","5+jets",zpt,weight);mon.fillHisto("ptw",tag_cat+"_5+jets",zpt,weight);}
+	    mon.fillHisto("ptw","alljets",zpt,weight);
+	    if(GoodIdJets.size()==3) {mon.fillHisto("ptw","3jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_3jets",zpt,xsecWeight*genWeight);}
+	    else if(GoodIdJets.size()==4) {mon.fillHisto("ptw","4jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_4jets",zpt,xsecWeight*genWeight);}
+	    else if(GoodIdJets.size()>=5) {mon.fillHisto("ptw","5+jets",zpt,xsecWeight*genWeight);mon.fillHisto("ptw",tag_cat+"_5+jets",zpt,xsecWeight*genWeight);}
 	}
 	  //	  if (!passMnBTag) continue; //at least 1 MediumWP b-tag if nBjets>0
 	  

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -1,0 +1,1783 @@
+{
+    "proc": [
+        {
+            "color": 1,
+            "data": [
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016B-17Jul2018_ver1-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016B_ver1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016B-17Jul2018_ver2-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                       "/MuonEG/Run2016C-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016D-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016E-17Jul2018-v2/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016F-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016G-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/MuonEG/Run2016H-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_MuEG2016H",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-17Jul2018_ver1-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016B_ver1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016B-17Jul2018_ver2-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016C-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016D-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016E-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016F-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016G-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleElectron2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleElectron/Run2016H-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleElectron2016H",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-17Jul2018_ver1-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016B_ver1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016B-17Jul2018_ver2-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016C-17Jul2018-v1/MINIAOD" 
+                    ],
+                     "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016D-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016E-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016F-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016G-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_SingleMuon2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/SingleMuon/Run2016H-17Jul2018-v1/MINIAOD" 
+                    ],
+                    "gtag": "80X_dataRun2_Prompt_v16",
+                    "dtag": "Data13TeV_SingleMuon2016H",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016B-17Jul2018_ver1-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016B_ver1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016B-17Jul2018_ver2-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016C-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/DoubleMuon/Run2016D-17Jul2018-v1/MINIAOD" 
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleMuon/Run2016E-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleMuon/Run2016F-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleMuon/Run2016G-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleMuon/Run2016H-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleMuon2016H",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016B-17Jul2018_ver1-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016B_ver1",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+		 {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016B-17Jul2018_ver2-v1/MINIAOD"	
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016B_ver2",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016C-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016C",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016D-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016D",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016E-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016E",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016F-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016F",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016G-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016G",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+			"/DoubleEG/Run2016H-17Jul2018-v1/MINIAOD"
+                    ],
+		    "gtag": "94X_dataRun2_v10",
+                    "dtag": "Data13TeV_DoubleEle2016H",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "xsec": 1.0
+                }
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+		"haa_prod",
+                "haa_mcbased",
+		"haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data"
+        },
+        {
+            "color": 852,
+            "data": [
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+                       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM" 
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_ZZ_ext1_2016",
+                    "xsec": 17.72 
+                },
+                {
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+		       "/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"	
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_ZZ_2016",
+                    "xsec": 17.72
+                },
+                 {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+		       "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WW2l2nu_2016",
+                    "xsec": 12.178
+                },
+                {
+                    "br": [
+                        0.23
+                    ],
+                    "dset": [
+		       "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WWlnu2q_2016",
+                    "xsec": 49.997
+                },
+                {
+                    "br": [
+                        0.77
+                    ],
+                    "dset": [
+		       "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WWlnu2q_ext1_2016",
+                    "xsec": 49.997
+		},
+		  {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/WWTo4Q_13TeV-powheg/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WW4q_2016",
+                    "xsec": 51.723
+                },
+                {
+                     "br": [
+                        0.25
+                    ],
+                    "dset": [
+		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WZ_2016",
+                    "xsec": 47.13 
+                    },
+                   {
+                    "br": [
+                        0.75
+                    ],
+                    "dset": [
+		       "/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WZ_ext1_2016",
+                    "xsec": 47.13 
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_ZZZ_2016",
+                    "xsec": 0.01398
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WZZ_2016",
+                    "xsec": 0.05565
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WWZ_2016",
+                    "xsec": 0.1651
+                },
+                {
+                   "br": [
+                     1.0
+                   ],
+                   "dset": [
+		      "/WWW_4F_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                   ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                   "dtag": "MC13TeV_WWW_4F_2016",
+                   "xsec": 0.2086
+                }, 
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_SingleT_s_2016",
+                    "xsec": 3.362
+                },
+                {
+                   "br": [                                                                                                                                         
+                        1.0  
+                    ], 
+                    "dset": [ 
+		       "/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_SingleT_t_2016",
+                    "xsec": 136.02 
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_SingleT_at_2016",
+                    "xsec": 80.95
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_SingleT_atW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_SingleT_tW_2016",
+                    "xsec": 35.6
+                },
+                {
+                    "br": [
+                        0.33
+                    ],
+                    "dset": [
+		       "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTGJets_2016",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [
+                        0.67
+                    ],
+                    "dset": [
+		       "/TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTGJets_ext1_2016",
+                    "xsec": 3.697
+                },
+                {
+                    "br": [
+                        0.16
+                    ],
+                    "dset": [
+		       "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TGJets_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        0.84
+                    ],
+                    "dset": [
+		       "/TGJets_TuneCUETP8M1_13TeV_amcatnlo_madspin_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TGJets_ext1_2016",
+                    "xsec": 2.967
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+		       "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTWJetslnu_2016",
+                    "xsec": 0.2043
+                },
+                {
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+		       "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTZJets2l2nu_2016",
+                    "xsec": 0.2529
+                },
+		 {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WplusH_HToBB_WToLNu_2016",
+                    "xsec": 0.053
+                 },
+		 {
+                    "br": [
+                       0.59
+                     ],
+                    "dset": [ 
+		       "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_ext1_2016",
+                    "xsec": 0.03369
+                 },
+		 {
+                    "br": [
+                       0.41
+                     ],
+                    "dset": [ 
+		       "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WminusH_HToBB_WToLNu_2016",
+                    "xsec": 0.03369
+                 },
+		 {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_ZH_HToBB_ZToLL_2016",
+                    "xsec": 0.04865  
+                 }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_prod",
+                "haa_mcbased"
+            ],
+            "tag": "Other Bkgds"
+        },
+       {
+            "color": 833,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_mcbased"
+            ],
+	     "mctruthmode": 5,
+            "tag": "t#bar{t} + b#bar{b}"
+       },
+	{
+            "color": 408,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+	        "haa_mcbased"
+            ],
+	     "mctruthmode": 4,
+            "tag": "t#bar{t} + c#bar{c}"
+        },
+	{
+            "color": 406,
+            "data": [
+                {
+                    "br": [
+                       1.0
+                     ],
+                    "dset": [ 
+		       "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                     ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_TTJets_powheg_2016",
+                    "xsec": 831.76  
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+	        "haa_mcbased"
+            ],
+	     "mctruthmode": 1,
+            "tag": "t#bar{t} + light"
+        }, 
+	{
+	    "color": 624,
+	    "data":[
+	        {
+		    "br": [1.0],
+		    "dset": [
+		       "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v3/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mcRun2_asymptotic_v3",
+		    "dtag": "MC13TeV_DYJetsToLL_10to50_amcNLO_2016",
+		    "xsec": 18610
+		},
+		{
+		    "br": [1.0],
+		    "dset": [
+		       "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v1/MINIAODSIM"
+		    ],
+		    "gtag": "94X_mcRun2_asymptotic_v3",
+		    "dtag": "MC13TeV_DYJetsToLL_50toInf_amcNLO_ext2_2016",
+		    "xsec": 5765.4
+		}
+	    ],
+	    "isdata": false,
+	    "keys": [
+	        "haa_prod",
+		"haa_ztoll"
+	    ],
+	    "tag": "Z#rightarrow ll"
+	},
+	{
+            "color": 624,
+            "data": [
+                {
+                    "br": [ 1.0 ],
+                    "dset": [
+		       "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
+                    "xsec": 18610
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY1JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY1JetsToLL_10to50_2016",
+                    "xsec": 725
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY2JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY2JetsToLL_10to50_2016",
+                    "xsec": 394.5
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY3JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY3JetsToLL_10to50_2016",
+                    "xsec": 96.47
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY4JetsToLL_M-10to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY4JetsToLL_10to50_2016",
+                    "xsec": 34.84
+                },
+                {
+                    "br": [ 0.35 ],
+                    "dset": [
+		       "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
+                    "xsec": 4895
+                },
+                {
+                    "br": [ 0.65 ],
+                    "dset": [
+		       "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
+                    "xsec": 4895
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY1JetsToLL_50toInf_2016",
+                    "xsec": 1016
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY2JetsToLL_50toInf_2016",
+                    "xsec": 331.4
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY3JetsToLL_50toInf_2016",
+                    "xsec": 96.36
+                },
+                {
+                    "br": [ 1 ],
+                    "dset": [
+		       "/DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],                                                                                                                                                                                      
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_DY4JetsToLL_50toInf_2016",
+                    "xsec": 51.4
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_ztoll",
+		"haa_mcbased"
+            ],
+	    "mctruthmode":31,
+            "tag": "Z#rightarrow ll"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                       0.09
+                    ],
+                    "dset": [
+		       "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WJets_amcNLO_2016",
+                    "xsec": 60430
+                },
+                {
+                    "br": [
+                       0.91
+                    ],
+                    "dset": [
+		       "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WJets_amcNLO_ext2_2016",
+                    "xsec": 60430
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod"
+            ],
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 622,
+            "data": [
+                {
+                    "br": [
+                       0.33
+                    ],
+                    "dset": [
+		       "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WJets_2016",
+                    "xsec": 50690
+                },
+                {   
+                    "br": [
+                        0.67
+                    ],
+                    "dset": [
+		       "/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_WJets_ext2_2016",
+                    "xsec": 50690
+                },
+                {   
+                    "br": [
+                        1
+                    ],
+                    "dset": [
+		       "/W1JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W1Jets_2016",
+                    "xsec": 9493
+                },
+                {   
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+		       "/W2JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W2Jets_2016",
+                    "xsec": 3120
+                },
+                {   
+                    "br": [
+                        0.5
+                    ],
+                    "dset": [
+		       "/W2JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W2Jets_ext1_2016",
+                    "xsec": 3120
+                },
+                {   
+                    "br": [
+                        0.33
+                    ],
+                    "dset": [
+		       "/W3JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W3Jets_2016",
+                    "xsec": 942.3
+                },
+                {   
+                    "br": [
+                        0.67
+                    ],
+                    "dset": [
+		       "/W3JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W3Jets_ext1_2016",
+                    "xsec": 942.3
+                },
+                {   
+                    "br": [
+                        0.815
+                    ],
+                    "dset": [
+		       "/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W4Jets_2016",
+                    "xsec": 524.2
+                },
+                {   
+                    "br": [
+                        0.185
+                    ],
+                    "dset": [
+		       "/W4JetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_W4Jets_ext1_2016",
+                    "xsec": 524.2
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_mcbased",
+		"haa_prod"
+            ],
+	    "mctruthmode":41,
+            "tag": "W#rightarrow l#nu"
+        },
+        {
+            "color": 634,
+            "data": [
+                {
+                    "br": [
+                        0.46
+                    ],
+                    "dset": [
+		       "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_2016",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        0.54
+                    ],
+                    "dset": [
+		       "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt80To120_EMEnr_ext1_2016",
+                    "xsec": 350000
+                },
+                {
+                    "br": [
+                        0.46
+                    ],
+                    "dset": [
+		       "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_2016",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        0.54
+                    ],
+                    "dset": [
+		       "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt120To170_EMEnr_ext1_2016",
+                    "xsec": 62964
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt170To300_EMEnr_2016",
+                    "xsec": 18810
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt300ToInf_EMEnr_2016",
+                    "xsec": 1350
+                },
+                {
+                    "br": [
+                        0.582
+                    ],
+                    "dset": [
+		       "/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_2016",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        0.414
+                    ],
+                    "dset": [
+		       "/QCD_Pt-80to120_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt80to120_MuEnrPt5_ext1_2016",
+                    "xsec": 106033.6648
+                },
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+		       "/QCD_Pt-120to170_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt120to170_MuEnrPt5_2016",
+                    "xsec": 25190.51514
+                },
+                {
+                    "br": [
+                        0.68
+                    ],
+                    "dset": [
+		       "/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_backup_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_2016",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        0.32
+                    ],
+                    "dset": [
+		       "/QCD_Pt-170to300_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt170to300_MuEnrPt5_ext1_2016",
+                    "xsec": 8654.49315
+                },
+                {
+                    "br": [
+                        0.24
+                    ],
+                    "dset": [
+		       "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_2016",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.76
+                    ],
+                    "dset": [
+		       "/QCD_Pt-300to470_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt300to470_MuEnrPt5_ext2_2016",
+                    "xsec": 797.35269
+                },
+                {
+                    "br": [
+                        0.204
+                    ],
+                    "dset": [
+		       "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.291
+                    ],
+                    "dset": [
+		       "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_ext1_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.504
+                    ],
+                    "dset": [
+		       "/QCD_Pt-470to600_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt470to600_MuEnrPt5_ext2_2016",
+                    "xsec": 79.02553776
+                },
+                {
+                    "br": [
+                        0.40
+                    ],
+                    "dset": [
+		       "/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_2016",
+                    "xsec": 25.09505908
+                },
+                {
+                    "br": [
+                        0.60
+                    ],
+                    "dset": [
+		       "/QCD_Pt-600to800_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt600to800_MuEnrPt5_ext1_2016",
+                    "xsec": 25.09505908
+                },
+                {
+                    "br": [
+                        0.20
+                    ],
+                    "dset": [
+		       "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.30
+                    ],
+                    "dset": [
+		       "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_ext1_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.50
+                    ],
+                    "dset": [
+		       "/QCD_Pt-800to1000_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext2-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt800to1000_MuEnrPt5_ext2_2016",
+                    "xsec": 4.707368272
+                },
+                {
+                    "br": [
+                        0.293
+                    ],
+                    "dset": [
+		       "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_2016",
+                    "xsec": 1.62131692
+                },
+                {
+                    "br": [
+                        0.707
+                    ],
+                    "dset": [
+		       "/QCD_Pt-1000toInf_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt1000toInf_MuEnrPt5_ext1_2016",
+                    "xsec": 1.62131692
+		},     
+                {
+                    "br": [
+                        0.01183
+                    ],
+                    "dset": [
+		       "/QCD_Pt_80to170_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_backup_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt_80to170_bcToE_2016",
+                    "xsec": 3221000
+                },
+                {
+                    "br": [
+                        0.02492
+                    ],
+                    "dset": [
+		       "/QCD_Pt_170to250_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt_170to250_bcToE_2016",
+                    "xsec": 105771
+                },
+                {
+                    "br": [
+                        0.03375
+                    ],
+                    "dset": [
+		       "/QCD_Pt_250toInf_bcToE_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v2/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_QCD_Pt_250toInf_bcToE_2016",
+                    "xsec": 21094.1
+                }
+            ],
+            "isdata": false,
+            "keys": [
+		"haa_prod", 
+                "haa_mcbased"
+            ],
+            "tag": "QCD"
+	},
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass12_2016",
+                    "xsec": "1.37*0.61"
+                },
+		            {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-12_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass12_2016",
+                    "xsec": "0.8594*0.7521"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 3,
+            "resonance": 12,
+            "spimpose": true,
+            "tag": "Wh (12)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass15_2016",
+                    "xsec": "1.37*0.61"
+                },
+                {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-15_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass15_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 4,
+            "resonance": 15,
+            "spimpose": false,
+            "tag": "Wh (15)"
+        },
+       {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass20_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-20_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass20_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+	    "lstyle":2,
+            "resonance": 20,
+            "spimpose": true,
+            "tag": "Wh (20)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass25_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-25_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass25_2016",
+                    "xsec": "0.8549*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 5, 
+            "resonance": 25,
+            "spimpose": false,
+            "tag": "Wh (25)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass30_2016",
+                    "xsec": "1.37*0.61"
+                },
+		{
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-30_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass30_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 6,
+            "resonance": 30,
+            "spimpose": false,
+            "tag": "Wh (30)"
+        },
+        {   
+            "data": [
+                {   
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass40_2016",
+                    "xsec": "1.37*0.61"
+                },
+		 {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-40_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass40_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3, 
+            "lstyle": 7, 
+            "resonance": 40,
+            "spimpose": false,
+            "tag": "Wh (40)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass50_2016",
+                    "xsec": "1.37*0.61"
+                },
+		            {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass50_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": true,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 2,
+            "lwidth": 3,
+            "lstyle": 2,
+            "resonance": 50,
+            "spimpose": false,
+            "tag": "Wh (50)"
+        },
+        {
+            "data": [
+                {
+                    "br": [
+                        0.3257 
+                    ],
+                    "dset": [
+			"/SUSYWHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Wh_amass60_2016",
+                    "xsec": "1.37*0.61"
+                },
+		  {
+                    "br": [
+                        0.10099
+                    ],
+                    "dset": [
+			"/SUSYZHToAA_AATo4B_M-60_TuneCUETP8M1_PSweights_13TeV-madgraph_pythia8/RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3-v1/MINIAODSIM"
+                    ],
+                    "gtag": "94X_mcRun2_asymptotic_v3",
+                    "dtag": "MC13TeV_Zh_amass60_2016",
+                    "xsec": "0.8594*0.7435"
+                }
+            ],
+            "fill": 0,
+            "isdata": false,
+            "isinvisible": false,
+            "issignal": true,
+            "keys": [
+		"haa_prod", 
+                "haa_signal",
+                "haa_mcbased"
+            ],
+            "lcolor": 1,
+            "lwidth": 3,
+            "lstyle": 1,
+            "resonance": 60,
+            "spimpose": true,
+            "tag": "Wh (60)"
+        }
+    ]
+}

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -12,7 +12,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016B_ver1",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt", 
                     "xsec": 1.0
                 },
 		 {
@@ -24,7 +24,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016B_ver2",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt", 
                     "xsec": 1.0
                 },
                 {
@@ -36,7 +36,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016C",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt", 
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt", 
                     "xsec": 1.0
                 },
                 {
@@ -48,7 +48,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016D",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -60,7 +60,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016E",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -72,7 +72,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016F",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -84,7 +84,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016G",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -96,7 +96,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_MuEG2016H",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -108,7 +108,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016B_ver1",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -120,7 +120,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016B_ver2",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -132,7 +132,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016C",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -144,7 +144,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016D",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -156,7 +156,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016E",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -168,7 +168,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016F",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -180,7 +180,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleElectron2016G",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -192,7 +192,7 @@
                     ],
                     "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleElectron2016H",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -204,7 +204,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016B_ver1",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -216,7 +216,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016B_ver2",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -228,7 +228,7 @@
                     ],
                      "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016C",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -240,7 +240,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016D",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -252,7 +252,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016E",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -264,7 +264,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016F",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -276,7 +276,7 @@
                     ],
                     "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_SingleMuon2016G",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -288,7 +288,7 @@
                     ],
                     "gtag": "80X_dataRun2_Prompt_v16",
                     "dtag": "Data13TeV_SingleMuon2016H",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
 		{
@@ -300,7 +300,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016B_ver1",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
 		{
@@ -312,7 +312,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016B_ver2",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -324,7 +324,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016C",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -336,7 +336,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016D",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -348,7 +348,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016E",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -360,7 +360,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016F",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -372,7 +372,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016G",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -384,7 +384,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleMuon2016H",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
 		 {
@@ -396,7 +396,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016B_ver1",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
 		 {
@@ -408,7 +408,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016B_ver2",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -420,7 +420,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016C",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -432,7 +432,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016D",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -444,7 +444,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016E",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -456,7 +456,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016F",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -468,7 +468,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016G",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 },
                 {
@@ -480,7 +480,7 @@
                     ],
 		    "gtag": "94X_dataRun2_v10",
                     "dtag": "Data13TeV_DoubleEle2016H",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_ReReco_07Aug2017_Collisions16_JSON.txt",
                     "xsec": 1.0
                 }
             ],


### PR DESCRIPTION
1. Add 2016 legacy json file;
2. Revert back to xsecWeight*genWeight when deriving the Z Pt  weights.