### PR TITLE
Updates on 2016 Legacy Json

### DIFF
--- a/test/haa4b/converter.sh
+++ b/test/haa4b/converter.sh
@@ -2,19 +2,19 @@
 # Note: this script is designed to be run under the folder: test/haa4b
 
 echo "Please select what you want to do:"
-echo "1. Switch 2016 to 2017   2. Switch 2017 to 2016"
+echo "1. Switch CMSSW_80X to CMSSW_94X(_10X)   2. Switch CMSSW_94X(_10X) to CMSSW_80X"
 read select
 
 if [ ${select} -eq 1 ]
 then
-    echo "Switching 2016 to 2017..."
+    echo "Switching CMSSW_80X to CMSSW_94X(_10X)..."
     com='/#define YEAR_2017/{s/.*YEAR_2017/#define YEAR_2017/g}'
 elif [ ${select} -eq 2 ]
 then
-    echo "Switching 2017 to 2016..."
+    echo "Switching CMSSW_94X(_10X) to CMSSW_80X..."
     com='s/#define YEAR_2017/\/\/#define YEAR_2017/g'
 else
-    echo "Input invalid, exsting..."
+    echo "Input invalid, exiting..."
     exit 0
 fi
 

--- a/test/haa4b/samples2016.json
+++ b/test/haa4b/samples2016.json
@@ -1627,7 +1627,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass25_2016",
-                    "xsec": "0.8549*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -1594,7 +1594,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass25_2016",
-                    "xsec": "0.8549*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -1008,7 +1008,6 @@
                 "haa_ztoll",
 		"haa_mcbased"
             ],
-	    "mctruthmode":31,
             "tag": "Z#rightarrow ll"
         },
         {
@@ -1151,7 +1150,6 @@
 		"haa_mcbased",
 		"haa_prod"
             ],
-	    "mctruthmode":41,
             "tag": "W#rightarrow l#nu"
         },
         {
@@ -1473,7 +1471,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass12_2016",
-                    "xsec": "0.8594*0.7521"
+                    "xsec": "0.9643*0.7521"
                 }
             ],
             "fill": 0,
@@ -1514,7 +1512,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass15_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,
@@ -1555,7 +1553,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass20_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,
@@ -1637,7 +1635,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass30_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,
@@ -1678,7 +1676,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass40_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,
@@ -1719,7 +1717,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass50_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,
@@ -1760,7 +1758,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass60_2016",
-                    "xsec": "0.8594*0.7435"
+                    "xsec": "0.9643*0.7435"
                 }
             ],
             "fill": 0,


### PR DESCRIPTION
1. Update on 2016 Legacy json:
    - remove the "mctruthmode" in DY and W Jets samples;
    - update cross sections in Zh signal samples.
2. Change naming in the converter.sh to clear the confusion.
