### PR TITLE
Updates to deal with HT VJets samples

### DIFF
--- a/bin/common/runPlotter.cc
+++ b/bin/common/runPlotter.cc
@@ -624,12 +624,14 @@ void SavingToFile(JSONWrapper::Object& Root, std::string RootDir, TFile* OutputF
          if(!Process[i].getBoolFromKeyword(matchingKeyword, "isdata", false) && !Process[i].getBoolFromKeyword(matchingKeyword, "isdatadriven", false)){
 	   Weight=iLumi/fileList.size();
 	   // Overwrite weight for W+Nj and DY+Nj samples
+	   /*
 	   if (dirProc.find("W#rightarrow l#nu")!=std::string::npos  && (Samples[j])["dtag"].toString().find("amcNLO")==std::string::npos) Weight=iLumi;
 	   if (dirProc.find("Z#rightarrow ll")!=std::string::npos && (Samples[j])["dtag"].toString().find("amcNLO")==std::string::npos) {
 	     if ((Samples[j])["dtag"].toString().find("10to50")!=std::string::npos && 
 		  ( (Samples[j])["dtag"].toString().find("2017")!=std::string::npos || (Samples[j])["dtag"].toString().find("2018")!=std::string::npos) );
 	     else Weight=iLumi;
 	   }
+	   */
 	   //	   if (Process[i].getStringFromKeyword(matchingKeyword, "tag", "W#rightarrow l#nu")) Weight=iLumi;
 	 } else {Weight=1.0;}  
 	 //	 {Weight= iLumi/fileList.size();}else{Weight=1.0;}

--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -275,6 +275,8 @@ int main(int argc, char* argv[])
 
     bool isMC_WJets = isMC && ( (string(url.Data()).find("MC13TeV_WJets")  != string::npos) || (string(url.Data()).find("MC13TeV_W1Jets")  != string::npos) || (string(url.Data()).find("MC13TeV_W2Jets")  != string::npos) || (string(url.Data()).find("MC13TeV_W3Jets")  != string::npos) || (string(url.Data()).find("MC13TeV_W4Jets")  != string::npos) );
     bool isMC_DY = isMC && ( (string(url.Data()).find("MC13TeV_DY")  != string::npos) );
+    bool isMC_DY_HTbin = isMC_DY && dtag.Contains("HT") ;
+    bool isMC_WJets_HTbin = isMC_WJets && dtag.Contains("HT") ;
     
     bool isMC_Wh = isMC && (string(url.Data()).find("Wh")  != string::npos); 
     bool isMC_Zh = isMC && (string(url.Data()).find("Zh")  != string::npos); 
@@ -1148,6 +1150,12 @@ int main(int argc, char* argv[])
             cout << "nDuplicates: " << nDuplicates << endl;
             continue;
         }
+	// VJets sample check: only use HT<70 events in the inclusive samples:
+	if((isMC_DY && !(isMC_DY_HTbin)) || (isMC_WJets && !(isMC_WJets_HTbin)) ) {
+	  if(is2017MC && dtag.Contains("10to50") && (ev.lheHt >= 100)) continue; // only exception: 2017 low mass DY HT samples start from 100 HT.
+	  if(ev.lheHt >= 70) continue;
+	}
+	mon.fillHisto("ht","debug_lheHt",ev.lheHt,1.0); 
 	if(is2018data) afterRun319077 = (ev.run > 319077);
 
         // add PhysicsEvent_t class, get all tree to physics objects
@@ -1166,7 +1174,8 @@ int main(int argc, char* argv[])
         {
           weight *= genWeight;
           //Here is the tricky part.,... rewrite xsecWeight for WJets/WXJets and DYJets/DYXJets
-          if( isMC_WJets && !dtag.Contains("amcNLO") )
+	  /*
+	  if( isMC_WJets && !dtag.Contains("amcNLO") )
 	    { xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(0, ev.lheNJets, is2016MC<<0|is2017MC<<1|is2018MC<<2); }
 	  else if( isMC_DY && !dtag.Contains("amcNLO") ) {
 	    if (string(url.Data()).find("10to50")  != string::npos)
@@ -1176,7 +1185,8 @@ int main(int argc, char* argv[])
 	    else
 	      { xsecWeight = xsecWeightCalculator::xsecWeightCalcLHEJets(2, ev.lheNJets, is2016MC<<0|is2017MC<<1|is2018MC<<2); }
 	  }
-          weight *= xsecWeight; 
+          */
+	  weight *= xsecWeight; 
         }
 
 	// Extract Z pt reweights from LO and NLO DY samples
@@ -2924,6 +2934,7 @@ int main(int argc, char* argv[])
 
 	  if(reweightTopPt && isMC_ttbar){
 	    double topptsf=1.0;
+	    /*
 	    if(is2016MC){ // formula for 2016
 	      if(!runZH){ // Wh
 		if(tag_subcat.Contains("3b")) topptsf = exp(0.04182-0.00095*wsum.pt());
@@ -2952,6 +2963,13 @@ int main(int argc, char* argv[])
 	      else if(runZH){ // Zh
 		if(tag_subcat.Contains("3b")) topptsf = exp(-0.18502+0.00059*wsum.pt());
 		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.23199+0.00076*wsum.pt());
+	      }
+	    }
+	    */
+	    if(is2018MC){
+	      if(!runZH){ // Wh
+		if(tag_subcat.Contains("3b")) topptsf = exp(0.08034-0.00026*ht);
+		else if(tag_subcat.Contains("4b")) topptsf = exp(-0.001373-0.00036*ht);
 	      }
 	    }
 //	    std::cout << tag_subcat << ", ptw " << wsum.pt() << ", sf: " << topptsf << std::endl;

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -909,7 +909,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2016",
-                    "xsec": 18610
+                    "xsec": "18610*1.23"
                 },
                 {
                     "br": [ 1 ],
@@ -918,7 +918,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT70to100_2016",
-                    "xsec": 301
+                    "xsec": "301*1.23"
                 },
                 {
                     "br": [ 0.105 ],
@@ -927,7 +927,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT100to200_2016",
-                    "xsec": 224
+                    "xsec": "224*1.23"
                 },
                 {
                     "br": [ 0.895 ],
@@ -936,7 +936,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT100to200_ext1_2016",
-                    "xsec": 224
+                    "xsec": "224*1.23"
                 },
                 {
                     "br": [ 0.33 ],
@@ -945,7 +945,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT200to400_2016",
-                    "xsec": 37.87
+                    "xsec": "37.87*1.23"
                 },
                 {
                     "br": [ 0.67 ],
@@ -954,7 +954,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT200to400_ext1_2016",
-                    "xsec": 37.87
+                    "xsec": "37.87*1.23"
                 },
                 {
                     "br": [ 0.33 ],
@@ -963,7 +963,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT400to600_2016",
-                    "xsec": 3.628
+                    "xsec": "3.628*1.23"
                 },
                 {
                     "br": [ 0.67 ],
@@ -972,7 +972,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT400to600_ext1_2016",
-                    "xsec": 3.628
+                    "xsec": "3.628*1.23"
                 },
                 {
                     "br": [ 0.34 ],
@@ -981,7 +981,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT600toInf_2016",
-                    "xsec": 1.107
+                    "xsec": "1.107*1.23"
                 },
                 {
                     "br": [ 0.66 ],
@@ -990,7 +990,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_5to50_HT600toInf_ext1_2016",
-                    "xsec": 1.107
+                    "xsec": "1.107*1.23"
                 },
                 {
                     "br": [ 0.35 ],
@@ -999,7 +999,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_ext1_2016",
-                    "xsec": 4895
+                    "xsec": "4895*1.23"
                 },
                 {
                     "br": [ 0.65 ],
@@ -1008,7 +1008,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_ext2_2016",
-                    "xsec": 4895
+                    "xsec": "4895*1.23"
                 },
                 {
                     "br": [ 1 ],
@@ -1017,7 +1017,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT70to100_2016",
-                    "xsec": 169.9
+                    "xsec": "169.9*1.23"
                 },
                 {
                     "br": [ 0.25 ],
@@ -1026,7 +1026,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT100to200_2016",
-                    "xsec": 147.4
+                    "xsec": "147.4*1.23"
                 },
                 {
                     "br": [ 0.75 ],
@@ -1035,7 +1035,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT100to200_ext1_2016",
-                    "xsec": 147.4
+                    "xsec": "147.4*1.23"
                 },
                 {
                     "br": [ 0.10 ],
@@ -1044,7 +1044,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT200to400_2016",
-                    "xsec": 40.99
+                    "xsec": "40.99*1.23"
                 },
                 {
                     "br": [ 0.90 ],
@@ -1053,7 +1053,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT200to400_ext1_2016",
-                    "xsec": 40.99
+                    "xsec": "40.99*1.23"
                 },
                 {
                     "br": [ 0.11 ],
@@ -1062,7 +1062,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT400to600_2016",
-                    "xsec": 5.674
+                    "xsec": "5.674*1.23"
                 },
                 {
                     "br": [ 0.89 ],
@@ -1071,7 +1071,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT400to600_ext1_2016",
-                    "xsec": 5.674
+                    "xsec": "5.674*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -1080,7 +1080,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT600to800_2016",
-                    "xsec": 1.367
+                    "xsec": "1.367*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -1089,7 +1089,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT800to1200_2016",
-                    "xsec": 0.6304
+                    "xsec": "0.6304*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -1098,7 +1098,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT1200to2500_2016",
-                    "xsec": 0.1514
+                    "xsec": "0.1514*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -1107,7 +1107,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_DYJetsToLL_50toInf_HT2500toInf_2016",
-                    "xsec": 0.003565
+                    "xsec": "0.003565*1.23"
                 }
             ],
             "isdata": false,
@@ -1271,7 +1271,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_2016",
-                    "xsec": 50690
+                    "xsec": "50690*1.21"
                 },
                 {   
                     "br": [
@@ -1282,7 +1282,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_ext2_2016",
-                    "xsec": 50690
+                    "xsec": "50690*1.21"
                 },
                 {   
                     "br": [
@@ -1293,7 +1293,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT70to100_2016",
-                    "xsec": 1353
+                    "xsec": "1353*1.21"
                 },
                 {   
                     "br": [
@@ -1304,7 +1304,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_2016",
-                    "xsec": 1346
+                    "xsec": "1346*1.21"
                 },
                 {   
                     "br": [
@@ -1315,7 +1315,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_ext1_2016",
-                    "xsec": 1346
+                    "xsec": "1346*1.21"
                 },
                 {   
                     "br": [
@@ -1326,7 +1326,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_ext2_2016",
-                    "xsec": 1346
+                    "xsec": "1346*1.21"
                 },
                 {   
                     "br": [
@@ -1337,7 +1337,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_2016",
-                    "xsec": 359.7
+                    "xsec": "359.7*1.21"
                 },
                 {   
                     "br": [
@@ -1348,7 +1348,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_ext1_2016",
-                    "xsec": 359.7
+                    "xsec": "359.7*1.21"
                 },
                 {   
                     "br": [
@@ -1359,7 +1359,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_ext2_2016",
-                    "xsec": 359.7
+                    "xsec": "359.7*1.21"
                 },
                 {   
                     "br": [
@@ -1370,7 +1370,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT400to600_2016",
-                    "xsec": 48.91
+                    "xsec": "48.91*1.21"
                 },
                 {   
                     "br": [
@@ -1381,7 +1381,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT400to600_ext1_2016",
-                    "xsec": 48.91
+                    "xsec": "48.91*1.21"
                 },
                 {   
                     "br": [
@@ -1392,7 +1392,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT600to800_2016",
-                    "xsec": 12.05
+                    "xsec": "12.05*1.21"
                 },
                 {   
                     "br": [
@@ -1403,7 +1403,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT600to800_ext1_2016",
-                    "xsec": 12.05
+                    "xsec": "12.05*1.21"
                 },
                 {   
                     "br": [
@@ -1414,7 +1414,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT800to1200_2016",
-                    "xsec": 5.501
+                    "xsec": "5.501*1.21"
                 },
                 {   
                     "br": [
@@ -1425,7 +1425,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT800to1200_ext1_2016",
-                    "xsec": 5.501
+                    "xsec": "5.501*1.21"
                 },
                 {   
                     "br": [
@@ -1436,7 +1436,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2016",
-                    "xsec": 1.329
+                    "xsec": "1.329*1.21"
                 },
                 {   
                     "br": [
@@ -1447,7 +1447,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT1200to2500_ext1_2016",
-                    "xsec": 1.329
+                    "xsec": "1.329*1.21"
                 },
                 {   
                     "br": [
@@ -1458,7 +1458,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2016",
-                    "xsec": 0.03216
+                    "xsec": "0.03216*1.21"
                 },
                 {   
                     "br": [
@@ -1469,7 +1469,7 @@
                     ],
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT2500toInf_ext1_2016",
-                    "xsec": 0.03216
+                    "xsec": "0.03216*1.21"
                 }
             ],
             "isdata": false,

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -726,7 +726,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2017",
-                    "xsec": 18610
+                    "xsec": "18610*1.23"
                 },
                 {
                     "br": [ 0.99 ],
@@ -735,7 +735,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_ext1_2017",
-                    "xsec": 18610
+                    "xsec": "18610*1.23*
                 },
                 {
                     "br": [ 1.0 ],
@@ -744,7 +744,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT100to200_2017",
-                    "xsec": 204
+                    "xsec": "204*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -753,7 +753,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT200to400_2017",
-                    "xsec": 54.4
+                    "xsec": "54.4*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -762,7 +762,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT400to600_2017",
-                    "xsec": 5.70
+                    "xsec": "5.70*1.23"
                 },
                 {
                     "br": [ 0.68 ],
@@ -771,7 +771,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT600toInf_2017",
-                    "xsec": 1.85
+                    "xsec": "1.85*1.23"
                 },
                 {
                     "br": [ 0.32 ],
@@ -780,7 +780,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT600toInf_ext1_2017",
-                    "xsec": 1.85
+                    "xsec": "1.85*1.23"
                 },
                 {
                     "br": [ 0.4977 ],
@@ -789,7 +789,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_2017",
-                    "xsec": 4895
+                    "xsec": "4895*1.23"
                 },
                 {
                     "br": [ 0.5023 ],
@@ -798,7 +798,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_ext1_2017",
-                    "xsec": 4895
+                    "xsec": "4895*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -807,7 +807,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT70to100_2017",
-                    "xsec": 146.9
+                    "xsec": "146.9*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -816,7 +816,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT100to200_2017",
-                    "xsec": 161.1
+                    "xsec": "161.1*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -825,7 +825,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT200to400_2017",
-                    "xsec": 48.66
+                    "xsec": "48.66*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -834,7 +834,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT400to600_2017",
-                    "xsec": 6.97
+                    "xsec": "6.97*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -843,7 +843,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT600to800_2017",
-                    "xsec": 1.743
+                    "xsec": "1.743*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -852,7 +852,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT800to1200_2017",
-                    "xsec": 0.805
+                    "xsec": "0.805*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -861,7 +861,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT1200to2500_2017",
-                    "xsec": 0.193
+                    "xsec": "0.193*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -870,7 +870,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT2500toInf_2017",
-                    "xsec": 0.00347
+                    "xsec": "0.00347*1.23"
                 }
             ],
             "isdata": false,
@@ -1002,7 +1002,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_ext1_2017",
-                    "xsec": 50690
+                    "xsec": "50690*1.21"
                 },
                 {
                     "br": [
@@ -1013,7 +1013,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_2017",
-                    "xsec": 50690
+                    "xsec": "50690*1.21"
                 },
                 {
                     "br": [
@@ -1024,7 +1024,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT70to100_2017",
-                    "xsec": 1292
+                    "xsec": "1292*1.21"
                 },
                 {
                     "br": [
@@ -1035,7 +1035,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT100to200_2017",
-                    "xsec": 1395
+                    "xsec": "1395*1.21"
                 },
                 {
                     "br": [
@@ -1046,7 +1046,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT200to400_2017",
-                    "xsec": 407.9
+                    "xsec": "407.9*1.21"
                 },
                 {
                     "br": [
@@ -1057,7 +1057,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT400to600_2017",
-                    "xsec": 57.48
+                    "xsec": "57.48*1.21"
                 },
                 {
                     "br": [
@@ -1068,7 +1068,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT600to800_2017",
-                    "xsec": 12.87
+                    "xsec": "12.87*1.21"
                 },
                 {
                     "br": [
@@ -1079,7 +1079,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT800to1200_2017",
-                    "xsec": 5.366
+                    "xsec": "5.366*1.21"
                 },
                 {
                     "br": [
@@ -1090,7 +1090,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2017",
-                    "xsec": 1.074
+                    "xsec": "1.074*1.21"
                 },
                 {
                     "br": [
@@ -1101,7 +1101,7 @@
                     ],
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2017",
-                    "xsec": 0.008001
+                    "xsec": "0.008001*1.21"
                 }
             ],
             "isdata": false,

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -624,7 +624,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_10to50_2018",
-                    "xsec": 18610
+                    "xsec": "18610*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -633,7 +633,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT70to100_2018",
-                    "xsec": 145.5
+                    "xsec": "145.5*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -642,7 +642,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT100to200_2018",
-                    "xsec": 204
+                    "xsec": "204*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -651,7 +651,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT200to400_2018",
-                    "xsec": 54.4
+                    "xsec": "54.4*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -660,7 +660,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT400to600_2018",
-                    "xsec": 5.7
+                    "xsec": "5.7*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -669,7 +669,7 @@
                     ],                                                                                                                                                                                      
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_4to50_HT600toInf_2018",
-                    "xsec": 1.85
+                    "xsec": "1.85*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -678,7 +678,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_2018",
-                    "xsec": 4895
+                    "xsec": "4895*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -687,7 +687,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT70to100_2018",
-                    "xsec": 146.9
+                    "xsec": "146.9*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -696,7 +696,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT100to200_2018",
-                    "xsec": 161.1
+                    "xsec": "161.1*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -705,7 +705,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT200to400_2018",
-                    "xsec": 48.66
+                    "xsec": "48.66*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -714,7 +714,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT400to600_2018",
-                    "xsec": 6.97
+                    "xsec": "6.97*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -723,7 +723,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT600to800_2018",
-                    "xsec": 1.743
+                    "xsec": "1.743*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -732,7 +732,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT800to1200_2018",
-                    "xsec": 0.805
+                    "xsec": "0.805*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -741,7 +741,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT1200to2500_2018",
-                    "xsec": 0.193
+                    "xsec": "0.193*1.23"
                 },
                 {
                     "br": [ 1.0 ],
@@ -750,7 +750,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_DYJetsToLL_M50_HT2500toInf_2018",
-                    "xsec": 0.00347
+                    "xsec": "0.00347*1.23"
                 }
             ],
             "isdata": false,
@@ -837,7 +837,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_2018",
-                    "xsec": 50960
+                    "xsec": "50960*1.21"
                 },
                 {
                     "br": [
@@ -848,7 +848,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT70to100_2018",
-                    "xsec": 1292
+                    "xsec": "1292*1.21"
                 },
                 {
                     "br": [
@@ -859,7 +859,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT100to200_2018",
-                    "xsec": 1395
+                    "xsec": "1395*1.21"
                 },
                 {
                     "br": [
@@ -870,7 +870,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT200to400_2018",
-                    "xsec": 407.9
+                    "xsec": "407.9*1.21"
                 },
                 {
                     "br": [
@@ -881,7 +881,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT400to600_2018",
-                    "xsec": 57.48
+                    "xsec": "57.48*1.21"
                 },
                 {
                     "br": [
@@ -892,7 +892,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT600to800_2018",
-                    "xsec": 12.87
+                    "xsec": "12.87*1.21"
                 },
                 {
                     "br": [
@@ -903,7 +903,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT800to1200_2018",
-                    "xsec": 5.366
+                    "xsec": "5.366*1.21"
                 },
                 {
                     "br": [
@@ -914,7 +914,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2018",
-                    "xsec": 1.074
+                    "xsec": "1.074*1.21"
                 },
                 {
                     "br": [
@@ -925,7 +925,7 @@
                     ],
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2018",
-                    "xsec": 0.008001
+                    "xsec": "0.008001*1.21"
                 }
             ],
             "isdata": false,


### PR DESCRIPTION
1. Add k-factor for (inclusive + HT-binned) VJets samples in json files;
2. Use events with lheHt<70 in the inclusive VJets samples (except 2017 low mass HT-binned DY starting from HT 100) and then HT-binned VJets samples in runhaaAnalysis.cc;
3. Calculate xsec weight normally for (inclusive + HT-binned) VJets samples in runhaaAnalysis.cc and runPlotter.cc