### PR TITLE
Fix in EWK corrections for VH signal samples

### DIFF
--- a/bin/haa4b/runhaaAnalysis.cc
+++ b/bin/haa4b/runhaaAnalysis.cc
@@ -311,23 +311,17 @@ int main(int argc, char* argv[])
       TFile *wmptfile = TFile::Open(inputFileWm);                                                                                                                                                          
       if(wmptfile->IsZombie() || !wmptfile->IsOpen()) {std::cout<<"Error, cannot open file: "<< inputFileWm<<std::endl;return -1;} 
       
-      h_Wm = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_rebin");
-      h_Wm->Scale(1./h_Wm->Integral()); h_Wm->SetDirectory(0); 
-      h_Wm_up = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_up_rebin");
-      h_Wm_up->Scale(1./h_Wm_up->Integral()); h_Wm_up->SetDirectory(0);     
-      h_Wm_down = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_down_rebin");
-      h_Wm_down->Scale(1./h_Wm_down->Integral()); h_Wm_down->SetDirectory(0);     
+      h_Wm = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_rebin");h_Wm->SetDirectory(0); 
+      h_Wm_up = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_up_rebin"); h_Wm_up->SetDirectory(0);     
+      h_Wm_down = (TH1F *)wmptfile->Get("SignalWeight_nloEWK_down_rebin"); h_Wm_down->SetDirectory(0);     
       wmptfile->Close();
 
       TFile *wpptfile = TFile::Open(inputFileWp);     
       if(wpptfile->IsZombie() || !wpptfile->IsOpen()) {std::cout<<"Error, cannot open file: "<< inputFileWp<<std::endl;return -1;}        
 
-      h_Wp = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_rebin");
-      h_Wp->Scale(1./h_Wp->Integral()); h_Wp->SetDirectory(0); 
-      h_Wp_up = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_up_rebin");
-      h_Wp_up->Scale(1./h_Wp_up->Integral()); h_Wp_up->SetDirectory(0);      
-      h_Wp_down = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_down_rebin");
-      h_Wp_down->Scale(1./h_Wp_down->Integral()); h_Wp_down->SetDirectory(0);      
+      h_Wp = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_rebin");h_Wp->SetDirectory(0); 
+      h_Wp_up = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_up_rebin"); h_Wp_up->SetDirectory(0);      
+      h_Wp_down = (TH1F *)wpptfile->Get("SignalWeight_nloEWK_down_rebin"); h_Wp_down->SetDirectory(0);      
       wpptfile->Close();                                                  
 
 
@@ -338,12 +332,9 @@ int main(int argc, char* argv[])
       TFile *zptfile = TFile::Open(inputFileZll);
       if(zptfile->IsZombie() || !zptfile->IsOpen()) {std::cout<<"Error, cannot open file: "<< inputFileZll<<std::endl;return -1;}   
       
-      h_Zll = (TH1F *)zptfile->Get("SignalWeight_nloEWK_rebin");
-      h_Zll->Scale(1./h_Zll->Integral()); h_Zll->SetDirectory(0);           
-      h_Zll_up = (TH1F *)zptfile->Get("SignalWeight_nloEWK_up_rebin");
-      h_Zll_up->Scale(1./h_Zll_up->Integral()); h_Zll_up->SetDirectory(0);            
-      h_Zll_down = (TH1F *)zptfile->Get("SignalWeight_nloEWK_down_rebin");
-      h_Zll_down->Scale(1./h_Zll_down->Integral()); h_Zll_down->SetDirectory(0);   
+      h_Zll = (TH1F *)zptfile->Get("SignalWeight_nloEWK_rebin"); h_Zll->SetDirectory(0);           
+      h_Zll_up = (TH1F *)zptfile->Get("SignalWeight_nloEWK_up_rebin"); h_Zll_up->SetDirectory(0);            
+      h_Zll_down = (TH1F *)zptfile->Get("SignalWeight_nloEWK_down_rebin"); h_Zll_down->SetDirectory(0);   
       zptfile->Close();       
     }
     

--- a/test/haa4b/samples2016_legacy.json
+++ b/test/haa4b/samples2016_legacy.json
@@ -1316,7 +1316,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_2016",
                     "nevts": 59028040,
-                    "xsec": "50690*1.21"
+                    "xsec": "50690*1.23"
                 },
                 {   
                     "br": [
@@ -1328,7 +1328,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_ext2_2016",
                     "nevts": 111213597,
-                    "xsec": "50690*1.21"
+                    "xsec": "50690*1.23"
                 },
                 {   
                     "br": [
@@ -1340,7 +1340,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT70to100_2016",
                     "nevts": 10020533,
-                    "xsec": "1353*1.21"
+                    "xsec": "1353*1.23"
                 },
                 {   
                     "br": [
@@ -1352,7 +1352,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_2016",
                     "nevts": 9945478,
-                    "xsec": "1346*1.21"
+                    "xsec": "1346*1.23"
                 },
                 {   
                     "br": [
@@ -1364,7 +1364,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_ext1_2016",
                     "nevts": 24307634,
-                    "xsec": "1346*1.21"
+                    "xsec": "1346*1.23"
                 },
                 {   
                     "br": [
@@ -1376,7 +1376,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT100to200_ext2_2016",
                     "nevts": 38593839,
-                    "xsec": "1346*1.21"
+                    "xsec": "1346*1.23"
                 },
                 {   
                     "br": [
@@ -1388,7 +1388,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_2016",
                     "nevts": 4238585,
-                    "xsec": "359.7*1.21"
+                    "xsec": "359.7*1.23"
                 },
                 {   
                     "br": [
@@ -1400,7 +1400,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_ext1_2016",
                     "nevts": 10833616,
-                    "xsec": "359.7*1.21"
+                    "xsec": "359.7*1.23"
                 },
                 {   
                     "br": [
@@ -1412,7 +1412,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT200to400_ext2_2016",
                     "nevts": 19914590,
-                    "xsec": "359.7*1.21"
+                    "xsec": "359.7*1.23"
                 },
                 {   
                     "br": [
@@ -1424,7 +1424,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT400to600_2016",
                     "nevts": 1963464,
-                    "xsec": "48.91*1.21"
+                    "xsec": "48.91*1.23"
                 },
                 {   
                     "br": [
@@ -1436,7 +1436,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT400to600_ext1_2016",
                     "nevts": 5796237,
-                    "xsec": "48.91*1.21"
+                    "xsec": "48.91*1.23"
                 },
                 {   
                     "br": [
@@ -1448,7 +1448,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT600to800_2016",
                     "nevts": 3779141,
-                    "xsec": "12.05*1.21"
+                    "xsec": "12.05*1.23"
                 },
                 {   
                     "br": [
@@ -1460,7 +1460,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT600to800_ext1_2016",
                     "nevts": 14908339,
-                    "xsec": "12.05*1.21"
+                    "xsec": "12.05*1.23"
                 },
                 {   
                     "br": [
@@ -1472,7 +1472,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT800to1200_2016",
                     "nevts": 1544513,
-                    "xsec": "5.501*1.21"
+                    "xsec": "5.501*1.23"
                 },
                 {   
                     "br": [
@@ -1484,7 +1484,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT800to1200_ext1_2016",
                     "nevts": 6286023,
-                    "xsec": "5.501*1.21"
+                    "xsec": "5.501*1.23"
                 },
                 {   
                     "br": [
@@ -1496,7 +1496,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2016",
                     "nevts": 244532,
-                    "xsec": "1.329*1.21"
+                    "xsec": "1.329*1.23"
                 },
                 {   
                     "br": [
@@ -1508,7 +1508,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT1200to2500_ext1_2016",
                     "nevts": 6627909,
-                    "xsec": "1.329*1.21"
+                    "xsec": "1.329*1.23"
                 },
                 {   
                     "br": [
@@ -1520,7 +1520,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2016",
                     "nevts": 253561,
-                    "xsec": "0.03216*1.21"
+                    "xsec": "0.03216*1.23"
                 },
                 {   
                     "br": [
@@ -1532,7 +1532,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_WJets_HT2500toInf_ext1_2016",
                     "nevts": 2384260,
-                    "xsec": "0.03216*1.21"
+                    "xsec": "0.03216*1.23"
                 }
             ],
             "isdata": false,
@@ -2007,7 +2007,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass12_2016",
                     "nevts": 1010516,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		            {
                     "br": [
@@ -2019,7 +2019,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass12_2016",
                     "nevts": 965463,
-                    "xsec": "0.8839*0.7521"
+                    "xsec": "0.8839*0.7521*1.0474"
                 }
             ],
             "fill": 0,
@@ -2050,7 +2050,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass15_2016",
                     "nevts": 996279,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -2062,7 +2062,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass15_2016",
                     "nevts": 990410,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2093,7 +2093,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass20_2016",
                     "nevts": 999279,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		{
                     "br": [
@@ -2105,7 +2105,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass20_2016",
                     "nevts": 965694,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2136,7 +2136,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass25_2016",
                     "nevts": 1010277,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		{
                     "br": [
@@ -2148,7 +2148,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass25_2016",
                     "nevts": 985066,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2179,7 +2179,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass30_2016",
                     "nevts": 998095,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		{
                     "br": [
@@ -2191,7 +2191,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass30_2016",
                     "nevts": 994159,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2222,7 +2222,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass40_2016",
                     "nevts": 1010418,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		 {
                     "br": [
@@ -2234,7 +2234,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass40_2016",
                     "nevts": 986613,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2265,7 +2265,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass50_2016",
                     "nevts": 995119,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		            {
                     "br": [
@@ -2277,7 +2277,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass50_2016",
                     "nevts": 993354,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,
@@ -2308,7 +2308,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Wh_amass60_2016",
                     "nevts": 1008303,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
 		  {
                     "br": [
@@ -2320,7 +2320,7 @@
                     "gtag": "94X_mcRun2_asymptotic_v3",
                     "dtag": "MC13TeV_Zh_amass60_2016",
                     "nevts": 974094,
-                    "xsec": "0.8839*0.7435"
+                    "xsec": "0.8839*0.7435*1.0474"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -1089,7 +1089,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_ext1_2017",
                     "nevts": 44587448,
-                    "xsec": "50690*1.21"
+                    "xsec": "50690*1.23"
                 },
                 {
                     "br": [
@@ -1101,7 +1101,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_2017",
                     "nevts": 33043732,
-                    "xsec": "50690*1.21"
+                    "xsec": "50690*1.23"
                 },
                 {
                     "br": [
@@ -1113,7 +1113,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT70to100_2017",
                     "nevts": 22229710,
-                    "xsec": "1292*1.21"
+                    "xsec": "1292*1.23"
                 },
                 {
                     "br": [
@@ -1125,7 +1125,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT100to200_2017",
                     "nevts": 35804623,
-                    "xsec": "1395*1.21"
+                    "xsec": "1395*1.23"
                 },
                 {
                     "br": [
@@ -1137,7 +1137,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT200to400_2017",
                     "nevts": 21192211,
-                    "xsec": "407.9*1.21"
+                    "xsec": "407.9*1.23"
                 },
                 {
                     "br": [
@@ -1149,7 +1149,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT400to600_2017",
                     "nevts": 14250114,
-                    "xsec": "57.48*1.21"
+                    "xsec": "57.48*1.23"
                 },
                 {
                     "br": [
@@ -1161,7 +1161,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT600to800_2017",
                     "nevts": 21582309,
-                    "xsec": "12.87*1.21"
+                    "xsec": "12.87*1.23"
                 },
                 {
                     "br": [
@@ -1173,7 +1173,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT800to1200_2017",
                     "nevts": 20272990,
-                    "xsec": "5.366*1.21"
+                    "xsec": "5.366*1.23"
                 },
                 {
                     "br": [
@@ -1185,7 +1185,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2017",
                     "nevts": 19991892,
-                    "xsec": "1.074*1.21"
+                    "xsec": "1.074*1.23"
                 },
                 {
                     "br": [
@@ -1197,7 +1197,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2017",
                     "nevts": 20629585,
-                    "xsec": "0.008001*1.21"
+                    "xsec": "0.008001*1.23"
                 }
             ],
             "isdata": false,
@@ -1444,7 +1444,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass12_2017",
                     "nevts": 953821,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1456,7 +1456,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass12_2017",
                     "nevts": 494730,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1487,7 +1487,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass15_2017",
                     "nevts": 938085,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1499,7 +1499,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass15_2017",
                     "nevts": 497206,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1530,7 +1530,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass20_2017",
                     "nevts": 958038,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1542,7 +1542,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass20_2017",
                     "nevts": 496767,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1572,7 +1572,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass25_2017",
                     "nevts": 934507,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1584,7 +1584,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass25_2017",
                     "nevts": 493933,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1615,7 +1615,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass30_2017",
                     "nevts": 934164,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1627,7 +1627,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass30_2017",
                     "nevts": 494739,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1658,7 +1658,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass40_2017",
                     "nevts": 955080,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1670,7 +1670,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass40_2017",
                     "nevts": 493704,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1701,7 +1701,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass50_2017",
                     "nevts": 937913,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1713,7 +1713,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass50_2017",
                     "nevts": 496637,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1744,7 +1744,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Wh_amass60_2017",
                     "nevts": 953433,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1756,7 +1756,7 @@
                     "gtag": "94X_mc2017_realistic_v14",
                     "dtag": "MC13TeV_Zh_amass60_2017",
                     "nevts": 496105,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,

--- a/test/haa4b/samples2018.json
+++ b/test/haa4b/samples2018.json
@@ -908,7 +908,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_2018",
                     "nevts": 1,
-                    "xsec": "50960*1.21"
+                    "xsec": "50960*1.23"
                 },
                 {
                     "br": [
@@ -920,7 +920,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT70to100_2018",
                     "nevts": 28060302,
-                    "xsec": "1292*1.21"
+                    "xsec": "1292*1.23"
                 },
                 {
                     "br": [
@@ -932,7 +932,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT100to200_2018",
                     "nevts": 29488310,
-                    "xsec": "1395*1.21"
+                    "xsec": "1395*1.23"
                 },
                 {
                     "br": [
@@ -944,7 +944,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT200to400_2018",
                     "nevts": 25423155,
-                    "xsec": "407.9*1.21"
+                    "xsec": "407.9*1.23"
                 },
                 {
                     "br": [
@@ -956,7 +956,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT400to600_2018",
                     "nevts": 5915969,
-                    "xsec": "57.48*1.21"
+                    "xsec": "57.48*1.23"
                 },
                 {
                     "br": [
@@ -968,7 +968,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT600to800_2018",
                     "nevts": 19699782,
-                    "xsec": "12.87*1.21"
+                    "xsec": "12.87*1.23"
                 },
                 {
                     "br": [
@@ -980,7 +980,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT800to1200_2018",
                     "nevts": 8362227,
-                    "xsec": "5.366*1.21"
+                    "xsec": "5.366*1.23"
                 },
                 {
                     "br": [
@@ -992,7 +992,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT1200to2500_2018",
                     "nevts": 7571583,
-                    "xsec": "1.074*1.21"
+                    "xsec": "1.074*1.23"
                 },
                 {
                     "br": [
@@ -1004,7 +1004,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_WJets_HT2500toInf_2018",
                     "nevts": 3191612,
-                    "xsec": "0.008001*1.21"
+                    "xsec": "0.008001*1.23"
                 }
             ],
             "isdata": false,
@@ -1299,7 +1299,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass12_2018",
                     "nevts": 1020300,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1311,7 +1311,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass12_2018",
                     "nevts": 496721,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1342,7 +1342,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass15_2018",
                     "nevts": 1022564,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1354,7 +1354,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass15_2018",
                     "nevts": 297501,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1385,7 +1385,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass20_2018",
                     "nevts": 1020605,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1397,7 +1397,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass20_2018",
                     "nevts": 494820,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1427,7 +1427,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass25_2018",
                     "nevts": 1021525,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1439,7 +1439,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass25_2018",
                     "nevts": 484463,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1470,7 +1470,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass30_2018",
                     "nevts": 1011352,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1482,7 +1482,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass30_2018",
                     "nevts": 490005,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1513,7 +1513,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass40_2018",
                     "nevts": 1019418,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1525,7 +1525,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass40_2018",
                     "nevts": 484314,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1556,7 +1556,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass50_2018",
                     "nevts": 1015129,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1568,7 +1568,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass50_2018",
                     "nevts": 472187,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,
@@ -1599,7 +1599,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Wh_amass60_2018",
                     "nevts": 1019047,
-                    "xsec": "1.37*0.61"
+                    "xsec": "1.37*0.61*1.076"
                 },
                 {
                     "br": [
@@ -1611,7 +1611,7 @@
                     "gtag": "102X_upgrade2018_realistic_v19",
                     "dtag": "MC13TeV_Zh_amass60_2018",
                     "nevts": 495592,
-                    "xsec": "0.8839*0.75"
+                    "xsec": "0.8839*0.75*1.0474"
                 }
             ],
             "fill": 0,


### PR DESCRIPTION
When applying the NLO EW correction to the VH signal, need to make sure that we don’t double-count the normalization effect.  See tables 27-29 here [1] and the formulas on the top of page 98. Basically we just want to rescale w/e effective cross section number we have taking out the delta_ewk.  For example, for W+H we have an effective scaling of

  (97.18 (1 - 0 (no EW correction)) + 1.20 + 3.09)  / (97.18 (1 - 0.074) + 1.20 + 3.09) 
= 101.47 / 94.26 ~ 1.076

So for W+H we adjust the inclusive cross section we have been using by a factor 1.076. Similar math for the W-H and ZH. 
Thanks to Stephane Cooperstein for pointing us to the recipe from the VHbb analysis .

[1] https://cds.cern.ch/record/2227475/files/CERN-2017-002-M.pdf