### PR TITLE
Added feature A, B, C

### DIFF
--- a/plugins/mainNtuplizer.cc
+++ b/plugins/mainNtuplizer.cc
@@ -221,6 +221,7 @@ class mainNtuplizer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   TH2F *h2_TightBTaggingEff_Num_b, *h2_TightBTaggingEff_Num_c, *h2_TightBTaggingEff_Num_udsg;
 
   bool isMC_ttbar;
+  bool isDATA_VBFH;
   bool is2016Signal;
   bool is2016;
   bool is2017;
@@ -346,6 +347,7 @@ mainNtuplizer::mainNtuplizer(const edm::ParameterSet& iConfig):
      printf("  Verbose set to false.  Will be quiet.\n") ;
   }
 
+  isDATA_VBFH = (string(proc_.c_str()).find("BTagCSV") != string::npos || string(proc_.c_str()).find("JetHT") != string::npos ) && !isMC_;
   is2016Signal	= (string(proc_.c_str()).find("2016") != string::npos && string(proc_.c_str()).find("h_amass") != string::npos );
   is2016	= string(proc_.c_str()).find("2016") != string::npos;
   is2017     	= (string(proc_.c_str()).find("2017") != string::npos);
@@ -880,7 +882,7 @@ void mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSet
       eeTrigger          = utils::passTriggerPatterns(tr,"HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*");// isolation version
       eeTrigger2         = utils::passTriggerPatterns(tr,"HLT_DoubleEle33_CaloIdL_MW_v*"); // non isolation version
       // 2017 RunB and C single electron trigger needs special treatment, see below
-      eTrigger           = utils::passTriggerPatterns(tr,"HLT_Ele32_WPTight_Gsf_v*"); //"HLT_Ele32_WPTight_Gsf_L1DoubleEG_v*";
+      eTrigger           = utils::passTriggerPatterns(tr,"HLT_Ele32_WPTight_Gsf_L1DoubleEG_v*"); //HLT_Ele32_WPTight_Gsf_v;
       eTrigger2          = utils::passTriggerPatterns(tr,"HLT_Ele35_WPTight_Gsf_v*");
       emuTrigger         = utils::passTriggerPatterns(tr,"HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*");
       emuTrigger2	 = utils::passTriggerPatterns(tr,"HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*");
@@ -906,8 +908,9 @@ void mainNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& iSet
    // https://twiki.cern.ch/twiki/bin/viewauth/CMS/Egamma2017DataRecommendations#Double%20Electron%20Triggers
    // https://github.com/Sam-Harper/usercode/blob/100XNtup/TrigTools/plugins/Ele32DoubleL1ToSingleL1Example.cc
    // https://github.com/Sam-Harper/usercode/blob/100XNtup/TrigTools/test/ele32DoubleToSingle.py
+   if (verbose_) std::cout << isDATA_VBFH << endl;
 #ifdef YEAR_2017
-   if(is2017BC){
+   if(is2017BC && !isDATA_VBFH){
       //so the filter names are all packed in miniAOD so we need to create a new collection of them which are unpacked
       std::vector<pat::TriggerObjectStandAlone> unpackedTrigObjs;
       for(auto& trigObj: *triggerObjects){

--- a/test/haa4b/runlocal_test_2017.py
+++ b/test/haa4b/runlocal_test_2017.py
@@ -2,131 +2,166 @@ import FWCore.ParameterSet.Config as cms
 
 from UserCode.bsmhiggs_fwk.mainNtuplizer_cfi import *
 
-#from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
-from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection      
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1
+process.MessageLogger.cerr.FwkReport.reportEvery = 5000
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 #load run conditions
-#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load('Configuration.Geometry.GeometryIdeal_cff')
-#process.load('Configuration.Geometry.GeometryRecoDB_cff')
-#process.load('Configuration.Geometry.GeometryReco_cff')
+#process.load('Configuration.Geometry.GeometryIdeal_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
-process.load('RecoMET.METFilters.ecalBadCalibFilter_cfi')
+
+process.options   = cms.untracked.PSet(
+   allowUnscheduled = cms.untracked.bool(True)
+)
+
+updateJetCollection(
+   process, 
+   jetSource = cms.InputTag('slimmedJets'), 
+   labelName = 'UpdatedJEC', 
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None')  
+# Update: Safe to always add 'L2L3Residual' as MC contains dummy L2L3Residual corrections (always set to 1) 
+)
+
+from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
+from RecoJets.JetProducers.PileupJetID_cfi import pileupJetId
+from RecoJets.JetProducers.PileupJetID_cfi import _chsalgos_106X_UL17
+process.pileupJetIdUpdated = pileupJetId.clone( 
+        jets=cms.InputTag('updatedPatJetsUpdatedJEC'),  #(Your JEC corrected jets here),
+        inputIsCorrected=True,
+        applyJec=False,
+        vertexes=cms.InputTag("offlineSlimmedPrimaryVertices"),
+        algos = cms.VPSet(_chsalgos_106X_UL17)
+    )
+
+#rerun energy correction for electrons
+setupEgammaPostRecoSeq(process,
+                       runEnergyCorrections=True,
+                       runVID=False, #saves CPU time by not needlessly re-running VID, if you want the Fall17V2 IDs, set this to True or remove (default is True)
+                       era='2017-UL')    
+#a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
+
+runMetCorAndUncFromMiniAOD(process,
+    isData=True
+    )
+
+process.mainNtuplizer.isMC = cms.bool(False)
+process.mainNtuplizer.dtag = cms.string("Data13TeV_JetHT_2017B")
+process.mainNtuplizer.xsec = cms.double(1.0)
+process.mainNtuplizer.mctruthmode = cms.int32(1)
+process.mainNtuplizer.verbose = cms.bool(True)
+process.mainNtuplizer.metFilterBitsTag = cms.InputTag('TriggerResults','','HLT')
+process.mainNtuplizer.Legacy2016 = cms.bool(False)
+process.mainNtuplizer.jetsTag = cms.InputTag('updatedPatJetsUpdatedJEC')
+
+###########################################################
+# Workflow START
+# We try to reproduce slimmedJetsAK8 collection
+# like in MiniAOD production but lower the pt cut to as low
+# as possible
+#
+############################################################
+from UserCode.bsmhiggs_fwk.puppiJetMETReclusteringTools import puppiAK8ReclusterFromMiniAOD
+
+from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import _pfDeepBoostedJetTagsAll as pfDeepBoostedJetTagsAll
+from RecoBTag.ONNXRuntime.pfHiggsInteractionNet_cff import _pfHiggsInteractionNetTagsProbs as pfHiggsInteractionNetTagsProbs
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsAll as pfParticleNetJetTagsAll
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetMassRegressionOutputs
+
+btagDiscriminatorsAK8 = cms.PSet(names = cms.vstring(
+'pfCombinedSecondaryVertexV2BJetTags',
+'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+# 'pfCombinedMVAV2BJetTags',
+'pfDeepCSVJetTags:probb',
+'pfDeepCSVJetTags:probc',
+'pfDeepCSVJetTags:probudsg',
+'pfDeepCSVJetTags:probbb',
+'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+'pfMassIndependentDeepDoubleBvLV2JetTags:probQCD',
+'pfMassIndependentDeepDoubleBvLV2JetTags:probHbb',
+'pfMassIndependentDeepDoubleCvLV2JetTags:probQCD',
+'pfMassIndependentDeepDoubleCvLV2JetTags:probHcc',
+'pfMassIndependentDeepDoubleCvBV2JetTags:probHbb',
+'pfMassIndependentDeepDoubleCvBV2JetTags:probHcc',
+)
+# + pfDeepBoostedJetTagsAll
++ pfParticleNetJetTagsAll
+# + pfHiggsInteractionNetTagsProbs
+# + _pfParticleNetMassRegressionOutputs
+)
+
+btagDiscriminatorsAK8Subjets = cms.PSet(names = cms.vstring(
+   'pfDeepCSVJetTags:probb',
+   'pfDeepCSVJetTags:probbb',
+ )
+)
+
+process = puppiAK8ReclusterFromMiniAOD(process,
+   runOnMC=False,
+   useExistingWeights=True,
+   btagDiscriminatorsAK8=btagDiscriminatorsAK8,
+   btagDiscriminatorsAK8Subjets=btagDiscriminatorsAK8Subjets,
+   reclusterAK8GenJets=False
+)
+
+process.patAlgosToolsTask.add(process.patJetPartons)
+
+###############################
+# Override some configurations
+# for reclustered AK8 Gen jets
+###############################
+#process.ak8GenJetsNoNu.jetPtMin = 10
+#process.ak8GenJetsNoNuSoftDrop.jetPtMin = 10
+#process.ak8GenJetsNoNuConstituents.cut = "pt > 10"
+
+#################################
+# Override some configurations
+# for reclustered AK8 Puppi jets
+#################################
+process.ak8PFJetsPuppi.jetPtMin = 15
+process.ak8PFJetsPuppiSoftDrop.jetPtMin = 15
+process.ak8PFJetsPuppiConstituents.cut = "pt > 15. && abs(rapidity()) < 2.4"
+
+finalAK8PuppiPt = 30
+process.selectedPatJetsAK8Puppi.cut = "pt > {}".format(finalAK8PuppiPt)
+process.selectedPatJetsAK8Puppi.cutLoose = ""
+process.selectedPatJetsAK8Puppi.nLoose = 0
+process.slimmedJetsAK8NoDeepTags.dropDaughters = cms.string("pt < {}".format(finalAK8PuppiPt))
+process.slimmedJetsAK8NoDeepTags.dropSpecific = cms.string("pt < {}".format(finalAK8PuppiPt))
+process.slimmedJetsAK8NoDeepTags.dropTagInfos = cms.string("pt < {}".format(finalAK8PuppiPt))
+
+#################################
+# For reclustered AK8 Puppi jets
+#################################
+process.mainNtuplizer.fatjetsTag = "slimmedJetsAK8"
+
+#######################################################
+#
+# Workflow END
+#
+#######################################################
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
 #------ Declare the correct global tag ------#
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-#process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v7'
-#process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_TrancheIV_v6'
-process.GlobalTag.globaltag = '94X_mc2017_realistic_v14'
-#process.GlobalTag.globaltag = '94X_dataRun2_v6'
+process.GlobalTag.globaltag = '106X_dataRun2_v37'
 
 process.options   = cms.untracked.PSet(
    allowUnscheduled = cms.untracked.bool(True),
-   SkipEvent = cms.untracked.vstring('ProductNotFound')
+   #SkipEvent = cms.untracked.vstring('ProductNotFound')
 )
 
-#run ecalBadCalibReducedMINIAODFilter
-#https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2
-baddetEcallist = cms.vuint32(
-    [872439604,872422825,872420274,872423218,
-     872423215,872416066,872435036,872439336,
-     872420273,872436907,872420147,872439731,
-     872436657,872420397,872439732,872439339,
-     872439603,872422436,872439861,872437051,
-     872437052,872420649,872422436,872421950,
-     872437185,872422564,872421566,872421695,
-     872421955,872421567,872437184,872421951,
-     872421694,872437056,872437057,872437313])
-
-process.ecalBadCalibReducedMINIAODFilter = cms.EDFilter(
-     "EcalBadCalibFilter",
-     EcalRecHitSource = cms.InputTag("reducedEgamma:reducedEERecHits"),
-     ecalMinEt        = cms.double(50.),
-     baddetEcal	      = baddetEcallist, 
-     taggingMode      = cms.bool(True),
-     debug	      = cms.bool(False)
-     )
-#rerun energy correction for electrons
-setupEgammaPostRecoSeq(process,
-    runVID=False, #saves CPU time by not needlessly re-running VID
-    era='2017-Nov17ReReco')
-#a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
-
-# to recluster both jets and MET and then recorrect and get the proper uncertainties
-# this example adds a postfix in the slimmedMET collection: postfix="TEST"
-#runMetCorAndUncFromMiniAOD(process,
-#    isData=False,
-#    pfCandColl=cms.InputTag("packedPFCandidates"),
-#    recoMetFromPFCs=True,
-#    CHS = True, #This is an important step and determines what type of jets to be reclustered
-#    reclusterJets = True,
-#    postfix="TEST"
-#    )
-
-runMetCorAndUncFromMiniAOD(process,
-    isData=False,
-#    isData=True,
-    )
-
-runMetCorAndUncFromMiniAOD(process,
-    isData = False,
-#    isData = True,
-    fixEE2017 = True,
-    fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139} ,
-    postfix = "ModifiedMET"
-    )
-
-process.mainNtuplizer.isMC = cms.bool(True)
-#process.mainNtuplizer.isMC = cms.bool(False)
-#process.mainNtuplizer.dtag = cms.string("MC13TeV_Wh_amass40_2017")
-process.mainNtuplizer.dtag = cms.string("MC13TeV_TTTo2L2Nu_powheg_2017")
-#process.mainNtuplizer.dtag = cms.string("MC13TeV_TTGJets_2017_ext1")
-#process.mainNtuplizer.dtag = cms.string("MC13TeV_TTToSemiLeptonic_powheg_2017")
-#process.mainNtuplizer.dtag = cms.string("MC13TeV_TTToHadronic_powheg_2017")
-#process.mainNtuplizer.dtag = cms.string("DATA13TeV_SingleElectron_2017B")
-#process.mainNtuplizer.dtag = cms.string("DATA13TeV_SingleElectron_2017D")
-#process.mainNtuplizer.dtag = cms.string("DATA13TeV_SingleElectron_2017F")
-#process.mainNtuplizer.dtag = cms.string("Data13TeV_MuEG2017B")
-#process.mainNtuplizer.dtag = cms.string("Data13TeV_MuEG2017C")
-#process.mainNtuplizer.dtag = cms.string("Data13TeV_MuEG2017D")
-#process.mainNtuplizer.dtag = cms.string("Data13TeV_MuEG2017F")
-process.mainNtuplizer.xsec = cms.double(1.0)
-process.mainNtuplizer.mctruthmode = cms.int32(1)
-process.mainNtuplizer.verbose = cms.bool(False)
-#process.mainNtuplizer.verbose = cms.bool(True)
-#process.mainNtuplizer.jetsTag = cms.InputTag('selectedUpdatedPatJets')
-#process.mainNtuplizer.verticesTag = cms.InputTag("offlineSlimmedPrimaryVertices")
-#process.mainNtuplizer.jetsTag = cms.InputTag('slimmedMETTEST')
-
-#process.mainNtuplizer.fatjetsTag = cms.InputTag('selectedPatJetsAK8PFCHS')
-#process.mainNtuplizer.fatjetsTag = cms.InputTag('packedPatJetsAK8PFCHSSoftDrop')
-#process.mainNtuplizer.fatjetsTag = cms.InputTag('slimmedJetsAK8PFPuppiSoftDropPacked')
-process.mainNtuplizer.metFilterBitsTag = cms.InputTag('TriggerResults','','HLT')
-process.mainNtuplizer.metsTag = cms.InputTag("slimmedMETsModifiedMET","","bsmAnalysis")
-process.mainNtuplizer.objects = cms.InputTag("slimmedPatTrigger")
-#process.mainNtuplizer.bits = cms.InputTag('TriggerResultsTest','','HLT')
-
 process.source = cms.Source("PoolSource",
-#	       	     fileNames = cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/SUSYZHToAA_AATo4B_M-50_TuneCUETP8M1_13TeV_madgraph_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/00000/BEEEFB4E-37C8-E811-A98B-001E6757E05C.root"),
-#              fileNames = cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/NMSSM_WHToAATo4b_M-125_M-12_madgraph_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/40000/00F6F5BE-8742-E811-90B6-B499BAABF212.root"),
-              fileNames = cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/FECD59BD-1842-E811-96D7-0242AC130002.root"),
-#              fileNames = cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/TTGJets_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14_ext1-v2/120000/FEED6629-6DD6-E811-8C28-E0071B745DC0.root"),
-#              fileNames = cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/ECA4210B-F058-E811-8EBF-509A4C74915C.root"),
-#              fileNames = cms.untracked.vstring("/store/mc/RunIIFall17MiniAODv2/TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/289E3510-5942-E811-9FDF-E0071B6CAD20.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017B/SingleElectron/MINIAOD/31Mar2018-v1/30000/04B05308-0038-E811-99AB-008CFAC94314.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017D/SingleElectron/MINIAOD/31Mar2018-v1/90000/4C22E5DC-1A39-E811-9DD3-24BE05C6E561.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017F/SingleElectron/MINIAOD/31Mar2018-v1/010000/72A98F53-E53B-E811-8945-0CC47A4C8E2E.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017B/MuonEG/MINIAOD/31Mar2018-v1/610000/86B6E7A3-8739-E811-96AF-002590DE6E52.root"),
-#               fileNames = cms.untracked.vstring("/store/data/Run2017C/MuonEG/MINIAOD/31Mar2018-v1/80000/FCABD91C-5E37-E811-8379-0CC47A5FBDC5.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017D/MuonEG/MINIAOD/31Mar2018-v1/100000/FE93310F-E837-E811-9CBE-B496910A8618.root"),
-#              fileNames = cms.untracked.vstring("/store/data/Run2017F/MuonEG/MINIAOD/31Mar2018-v1/80000/F632D544-F636-E811-A63B-FA163E5D77FE.root"),
+                            fileNames = cms.untracked.vstring("/store/data/Run2017B/JetHT/MINIAOD/UL2017_MiniAODv2-v1/260000/00EA7817-B2DB-E44A-9FD7-3FFB3778C024.root"),
                             inputCommands=cms.untracked.vstring( 
         'keep *', 
         'drop *_ctppsLocalTrackLiteProducer_*_RECO'
@@ -135,21 +170,22 @@ process.source = cms.Source("PoolSource",
 )
 
 process.TFileService = cms.Service("TFileService",
-#			fileName = cms.string("analysis_DATA_RunB.root")
-			fileName = cms.string("analysisMC_TTTo2L2Nu.root")
+			fileName = cms.string("analysis_Data13TeV_JetHT_2017B.root")
 )
 
-process.dump = cms.EDAnalyzer("EventContentAnalyzer")  
+process.pathRunPatAlgos = cms.Path(process.patAlgosToolsTask)
 
 #jetToolbox(process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True,addNsubSubjets=True,addSoftDropSubjets=True,addNsub=True,Cut="pt>20")
 #jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True, addSoftDropSubjets=True,addNsub=True, Cut="pt>20") 
 #jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True, addNsub=True, Cut="pt>20") 
 #process.p = cms.Path(process.dump)
 process.p = cms.Path( 
-#    process.fullPatMetSequenceTEST *
-#    process.ecalBadCalibReducedMINIAODFilter *
-    process.fullPatMetSequence *
-    process.fullPatMetSequenceModifiedMET *
-    process.egammaPostRecoSeq *
-    process.mainNtuplizer 
-    ) # * process.dump )	
+	  process.patJetCorrFactorsUpdatedJEC *
+          process.updatedPatJetsUpdatedJEC * 
+    	  process.pileupJetIdUpdated *
+	  process.fullPatMetSequence * 
+	  process.egammaPostRecoSeq *
+    	  process.mainNtuplizer )	
+
+
+

--- a/test/haa4b/samples2017.json
+++ b/test/haa4b/samples2017.json
@@ -12,7 +12,7 @@
                     ],
                     "dtag": "Data13TeV_MuEG2017B",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -25,7 +25,7 @@
                     ],
                     "dtag": "Data13TeV_MuEG2017C",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -38,7 +38,7 @@
                     ],
                     "dtag": "Data13TeV_MuEG2017D",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -51,7 +51,7 @@
                     ],
                     "dtag": "Data13TeV_MuEG2017E",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -64,7 +64,7 @@
                     ],
                     "dtag": "Data13TeV_MuEG2017F",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -77,7 +77,7 @@
                     ],
                     "dtag": "Data13TeV_SingleElectron2017B",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -90,7 +90,7 @@
                     ],
                     "dtag": "Data13TeV_SingleElectron2017C",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -103,7 +103,7 @@
                     ],
                     "dtag": "Data13TeV_SingleElectron2017D",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -116,7 +116,7 @@
                     ],
                     "dtag": "Data13TeV_SingleElectron2017E",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -129,7 +129,7 @@
                     ],
                     "dtag": "Data13TeV_SingleElectron2017F",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -142,7 +142,7 @@
                     ],
                     "dtag": "Data13TeV_SingleMuon2017B",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -155,7 +155,7 @@
                     ],
                     "dtag": "Data13TeV_SingleMuon2017C",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -168,7 +168,7 @@
                     ],
                     "dtag": "Data13TeV_SingleMuon2017D",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -181,7 +181,7 @@
                     ],
                     "dtag": "Data13TeV_SingleMuon2017E",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -194,7 +194,7 @@
                     ],
                     "dtag": "Data13TeV_SingleMuon2017F",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -207,7 +207,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleMuon2017B",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -220,7 +220,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleMuon2017C",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -233,7 +233,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleMuon2017D",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -246,7 +246,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleMuon2017E",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -259,7 +259,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleMuon2017F",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -272,7 +272,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleEle2017B",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -285,7 +285,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleEle2017C",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -298,7 +298,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleEle2017D",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -311,7 +311,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleEle2017E",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 },
@@ -324,7 +324,7 @@
                     ],
                     "dtag": "Data13TeV_DoubleEle2017F",
                     "gtag": "106X_dataRun2_v37",
-                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
                     "nevts": 1,
                     "xsec": 1.0
                 }
@@ -332,13 +332,158 @@
             "fill": 0,
             "isdata": true,
             "keys": [
-                "haa_prod_data",
+                "haa_prod_data_leptons",
                 "haa_mcbased",
                 "haa_dataOnly"
             ],
             "marker": 20,
             "msize": 0.7,
-            "tag": "data"
+            "tag": "data (leptons)"
+        },
+	{
+	    "color": 2,
+            "data": [
+                {
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/BTagCSV/Run2017B-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_BTagCSV_2017B",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/BTagCSV/Run2017C-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_BTagCSV_2017C",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/BTagCSV/Run2017D-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_BTagCSV_2017D",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+                },
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/BTagCSV/Run2017E-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_BTagCSV_2017E",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/BTagCSV/Run2017F-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_BTagCSV_2017F",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/JetHT/Run2017B-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_JetHT_2017B",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/JetHT/Run2017C-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_JetHT_2017C",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/JetHT/Run2017D-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_JetHT_2017D",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/JetHT/Run2017E-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_JetHT_2017E",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		},
+		{
+                    "br": [
+                        1.0
+                    ],
+                    "dset": [
+                        "/JetHT/Run2017F-UL2017_MiniAODv2-v1/MINIAOD"
+                    ],
+                    "dtag": "Data13TeV_JetHT_2017F",
+                    "gtag": "106X_dataRun2_v37",
+                    "lumiMask": "/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "nevts": 1,
+                    "xsec": 1.0
+		}
+            ],
+            "fill": 0,
+            "isdata": true,
+            "keys": [
+                "haa_prod_data_had",
+                "haa_mcbased",
+                "haa_dataOnly"
+            ],
+            "marker": 20,
+            "msize": 0.7,
+            "tag": "data (hadronic)"
         },
         {
             "color": 852,


### PR DESCRIPTION
_mainNtuplizer.cc_ : added isDATA_VBFH exception, along with the 2017BC that already existed, for the special treatment of Run B and C single electron triggers
_samples2017.json_: - added the block for JetHT and BTagCSV data
                                    - changed the lumiMask to the recommended for UL data
_runlocal_test_2017.py_: modified the script to match the current full analysis configuration file